### PR TITLE
docs: complete lean docs phase

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -1,0 +1,131 @@
+# Feedme Development Notes
+
+Use this file for implementation and release details. Product/spec context lives in `PROJECT.md`; public install docs live in `README.md`; phase tracking lives in `docs/roadmap/lean-refactor.md`.
+
+## Local stack
+
+- Python 3.11+
+- Flask
+- SQLite via built-in `sqlite3`
+- Vanilla browser JavaScript
+- Docker and Docker Compose v2
+
+## Repository conventions
+
+- No frontend framework.
+- No frontend build step.
+- No ORM; use raw parameterized SQLite queries.
+- Keep modules broad and domain-oriented; avoid one tiny file per helper.
+- Comment only non-obvious logic.
+- Do not add AI attribution comments or commit trailers.
+- Keep `CLAUDE.md`, `.claude/`, `.env`, `VERSION`, SQLite DBs, recipe JSON, and recipe images out of git.
+
+## Important paths
+
+- `server.py`: Flask app and route wiring.
+- `core/config.py`: `.env` read/write helper.
+- `core/db.py`: SQLite connection helper.
+- `core/schema.py`: idempotent schema migrations.
+- `modules/importer.py`: recipe JSON and DB CRUD/sync.
+- `modules/ai_chef.py`: AI recipe generation/text extraction/image generation.
+- `modules/rss_fetcher.py`: RSS feed import.
+- `modules/url_importer.py`: URL import.
+- `modules/camera.py`: image/vision import.
+- `modules/meal_planner.py`: meal plan CRUD and ingredient aggregation.
+- `modules/meal_plan_ai.py`: AI week-plan generation.
+- `modules/grocery.py`: pantry diff and shopping list logic.
+- `modules/pantry.py`: pantry CRUD.
+- `frontend/index.html`: SPA markup.
+- `frontend/*.js`: feature modules loaded directly by the browser.
+- `frontend/app.css`: app styles.
+
+## Development commands
+
+```bash
+python3 -m compileall -q core modules server.py
+docker compose up -d --build
+docker compose logs -f
+docker compose down
+```
+
+The compose file is `compose.yaml`.
+
+## GitHub workflow
+
+Use a branch and PR for non-trivial changes:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git checkout -b docs/example-change
+# edit, verify
+git add <files>
+git commit -m "docs: describe example change"
+git push -u origin HEAD
+gh pr create --title "docs: describe example change" --body "Closes #N"
+```
+
+Commit style in this workspace is imperative, lowercase, no period.
+
+## Release flow
+
+During development, update `[Unreleased]` in `CHANGELOG.md` only for changes a self-hoster upgrading the app would care about.
+
+When releasing:
+
+```bash
+git add CHANGELOG.md
+git commit -m "release vX.Y.Z"
+git tag vX.Y.Z
+git push && git push origin vX.Y.Z
+```
+
+The tag triggers GitHub Actions to build/publish Docker images and create the GitHub release.
+
+Do not push a release-intent commit without a matching tag.
+
+## AI configuration notes
+
+The current setting/env names are `PPQ_*` for compatibility:
+
+```env
+PPQ_API_KEY=...
+PPQ_BASE_URL=https://api.ppq.ai/v1
+PPQ_MODEL=...
+PPQ_IMAGE_MODEL=...
+PPQ_VISION_MODEL=...
+```
+
+Do not document fixed recommended model IDs unless they have just been verified. Prefer capability language:
+
+- text/chat model for recipe generation and extraction
+- image-generation model for generated food photos
+- vision-capable model for camera import
+
+## Verification checklist
+
+Before opening a PR:
+
+```bash
+git diff --check
+python3 -m compileall -q core modules server.py
+```
+
+When frontend files changed, also run the app and check the browser console.
+
+When import or AI behavior changed, test the specific path manually with safe sample data.
+
+When Docker/runtime behavior changed:
+
+```bash
+docker compose up -d --build
+docker compose ps
+docker compose logs --tail=100
+```
+
+## Lean refactor rules
+
+- Each phase must leave Feedme working independently.
+- One issue should generally map to one PR.
+- Do not merge half-migrations that rely on a later phase to restore behavior.
+- Keep old endpoints/settings compatible unless the issue explicitly says to break or migrate them.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,94 @@
+# Feedme Project Notes
+
+Feedme is a self-hosted recipe management and meal-planning app for a personal/home server. It imports recipes from AI generation, RSS feeds, URLs, pasted text, camera images, or manual JSON, then stores them as schema.org `Recipe` JSON and indexes them into SQLite for fast app workflows.
+
+## Product loop
+
+```text
+source -> recipe JSON -> SQLite index -> meal plan -> pantry diff -> grocery list
+```
+
+## Product principles
+
+- Recipes are portable schema.org JSON.
+- `recipes/*.json` is the canonical recipe source of truth.
+- SQLite is the query/index layer and can be rebuilt from JSON.
+- Imported/generated recipes land in staging first; the user approves them before they become active.
+- Images are separate from recipe JSON so image failures do not corrupt recipe data.
+- The app is designed for personal/home-network use, not a public multi-user SaaS.
+
+## App identity
+
+- App name: Feedme
+- Wordmark: `Feed` dark brown + `me` amber
+- Tagline: `RECIPE INTELLIGENCE`
+- Logo: steaming bowl mark
+- The logo/top banner should remain visible and recognizable.
+
+## Architecture
+
+- Backend: Python 3.11+ and Flask
+- Database: SQLite via raw `sqlite3`
+- Frontend: single-page vanilla JavaScript, no framework, no build step
+- Deployment: Docker container with host-mounted `recipes/`, `images/`, and `data/`
+- AI: OpenAI-compatible chat/image endpoints configured by the user
+
+## Data model overview
+
+Main tables:
+
+- `recipes`: SQLite index for recipe JSON files, including status, source, tags, ingredients, and image path.
+- `pantry`: foods available at home.
+- `meal_plan`: dated breakfast/lunch/dinner recipe assignments.
+- `shopping_list`: pantry diff output and manual shopping entries.
+- `settings`: app settings persisted by key/value.
+
+Recipe JSON should include the schema.org basics:
+
+- `@context`, `@type`
+- `name`, `slug`, `description`
+- `image`
+- `recipeIngredient`
+- `recipeInstructions`
+- `prepTime`, `cookTime`, `totalTime`
+- `recipeYield`, `recipeCategory`, `recipeCuisine`
+- `source_url`, `source_type`, `status`
+
+## Import sources
+
+- AI generation: prompt to staged recipe JSON, optionally with generated image.
+- RSS import: feed items become staged recipes after page scrape/normalization.
+- URL import: JSON-LD or page content becomes one staged recipe.
+- Text import: pasted recipe text becomes one staged recipe.
+- Camera import: uploaded recipe images go through a vision-capable model and become one staged recipe.
+- Manual import: user-provided recipe JSON can be saved directly.
+
+## AI provider model guidance
+
+Feedme keeps `PPQ_*` setting names for compatibility with existing installs, but the recipe/text/vision calls are intended to work with OpenAI-compatible endpoints.
+
+Do not hardcode current model recommendations in project docs. Provider model IDs change often. Describe model requirements by capability:
+
+- Recipe/text model: supports chat/text generation.
+- Vision model: supports image inputs.
+- Image model: supports the configured image generation endpoint.
+
+PPQ-specific balance/top-up helpers are convenience features and are separate from the OpenAI-compatible recipe generation path.
+
+## User-visible API areas
+
+- Recipes: list/detail/approve/trash/restore/permanent delete/sync/favorite/cook log.
+- AI: provider test, recipe generation, text extraction, nutrition estimation, image regeneration.
+- Imports: RSS, URL, camera, manual, text.
+- Pantry: CRUD.
+- Meal plan: week view, add/update/delete entries, templates, AI planning.
+- Grocery: generate list, update items, manual add/delete.
+- Maintenance: backup, restore, version check, static assets.
+
+## Non-goals unless explicitly requested
+
+- Frontend framework or build tooling.
+- ORM layer.
+- Public multi-user authentication system.
+- External hosted database.
+- Committing personal recipe data, runtime DBs, images, `.env`, or generated `VERSION` files.

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ services:
 ```env
 PPQ_API_KEY=your-key-here
 PPQ_BASE_URL=https://api.ppq.ai/v1
-PPQ_MODEL=claude-haiku-4-5
-PPQ_IMAGE_MODEL=gpt-image-2
-PPQ_VISION_MODEL=claude-haiku-4-5
+PPQ_MODEL=your-text-model-id
+PPQ_IMAGE_MODEL=your-image-model-id
+PPQ_VISION_MODEL=your-vision-capable-model-id
 
 FLASK_SECRET=change-me-to-something-random
 ```
@@ -75,9 +75,15 @@ docker compose pull && docker compose up -d
 
 ## AI Provider
 
-Feedme uses any OpenAI-compatible endpoint. The recommended provider is [PPQ.ai](https://ppq.ai), which gives access to Claude and OpenAI models via a single API key and endpoint.
+Feedme uses OpenAI-compatible endpoints for recipe text, extraction, vision, and image generation. The default configuration names are still `PPQ_*` for compatibility with existing installs, and PPQ.ai is one supported provider.
 
-You can configure the key and models directly in the Settings tab after first launch. PPQ.ai offers a wide range of text, vision, and image generation models — pick what suits your budget and quality preferences.
+Configure the key, base URL, and model IDs in the Settings tab after first launch. Choose models by capability rather than by stale examples:
+
+- `PPQ_MODEL`: text/chat model for recipe generation and text extraction
+- `PPQ_IMAGE_MODEL`: image-generation model for food photos
+- `PPQ_VISION_MODEL`: vision-capable model for camera/image import
+
+Provider model IDs change often, so check your provider's current model list before filling these values.
 
 ---
 

--- a/docs/roadmap/lean-refactor.md
+++ b/docs/roadmap/lean-refactor.md
@@ -23,7 +23,7 @@ Make Feedme easier for humans and agents to modify while reducing stale docs, AI
 
 ## Phase status
 
-- Phase 1: Planned — [#51](https://github.com/sette7blo/feedme/issues/51)
+- Phase 1: Done — [#51](https://github.com/sette7blo/feedme/issues/51)
 - Phase 2: Planned — [#52](https://github.com/sette7blo/feedme/issues/52)
 - Phase 3: Planned — [#53](https://github.com/sette7blo/feedme/issues/53)
 - Phase 4: Planned — [#54](https://github.com/sette7blo/feedme/issues/54)
@@ -34,16 +34,16 @@ Make Feedme easier for humans and agents to modify while reducing stale docs, AI
 ## Phases
 
 ### Phase 1 — Lean Feedme docs and remove stale model guidance
-Status: Planned
+Status: Done
 GitHub issue: [#51](https://github.com/sette7blo/feedme/issues/51)
 
 Goal: Reduce agent context cost and stale guidance by making the project docs easier to scan and less tied to old model IDs.
 
 Acceptance:
-- [ ] `CLAUDE.md` is short enough to serve as an agent entrypoint, not an encyclopedia.
-- [ ] Docs describe model capabilities instead of prescribing stale model IDs.
-- [ ] Settings placeholders do not encourage old defaults like `gpt-4o-mini`, `dall-e-3`, or `gpt-4o` unless verified current.
-- [ ] No secrets or personal runtime data are added to git.
+- [x] `CLAUDE.md` is short enough to serve as an agent entrypoint, not an encyclopedia.
+- [x] Docs describe model capabilities instead of prescribing stale model IDs.
+- [x] Settings placeholders use capability-based text and avoid stale model IDs.
+- [x] No secrets or personal runtime data are added to git.
 
 ### Phase 2 — Centralize AI provider and model config
 Status: Planned

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -395,7 +395,7 @@
             </div>
             <div class="settings-section-body">
               <div class="form-group">
-                <label class="form-label">PPQ.ai API Key</label>
+                <label class="form-label">OpenAI-compatible API Key</label>
                 <div class="secret-wrap">
                   <input type="password" id="s-ppq-key" class="form-input" placeholder="Enter your key…">
                   <button type="button" class="secret-eye" onclick="toggleSecret('s-ppq-key',this)" tabindex="-1">
@@ -414,11 +414,11 @@
               </div>
               <div class="form-group"><label class="form-label">Base URL</label><input id="s-ppq-url" class="form-input" value="https://api.ppq.ai/v1"></div>
               <div class="form-row">
-                <div class="form-group"><label class="form-label">Recipe Model</label><input id="s-ppq-model" class="form-input" placeholder="gpt-4o-mini"></div>
-                <div class="form-group"><label class="form-label">Image Model</label><input id="s-ppq-image-model" class="form-input" placeholder="dall-e-3"></div>
-                <div class="form-group"><label class="form-label">Vision Model</label><input id="s-ppq-vision-model" class="form-input" placeholder="gpt-4o"></div>
+                <div class="form-group"><label class="form-label">Recipe Model</label><input id="s-ppq-model" class="form-input" placeholder="text/chat model id"></div>
+                <div class="form-group"><label class="form-label">Image Model</label><input id="s-ppq-image-model" class="form-input" placeholder="image-generation model id"></div>
+                <div class="form-group"><label class="form-label">Vision Model</label><input id="s-ppq-vision-model" class="form-input" placeholder="vision-capable model id"></div>
               </div>
-              <div style="font-size:11px;color:var(--text-muted);margin-bottom:10px">Vision model is used for Import from Image. Must support image inputs (e.g. gpt-4o).</div>
+              <div style="font-size:11px;color:var(--text-muted);margin-bottom:10px">Vision model is used for Import from Image and must support image inputs. Check your provider's current model list before choosing model IDs.</div>
               <div style="display:flex;align-items:center;gap:12px">
                 <button class="btn btn-ghost btn-sm" id="ai-test-btn" onclick="testAiConnection()">Test Connection</button>
                 <span id="ai-balance" style="font-size:12px;font-weight:600;color:var(--text-mid);display:none"></span>


### PR DESCRIPTION
## Summary
- add tracked `PROJECT.md` and `DEV.md` so stable product/dev context is easy to find without relying on the ignored local `CLAUDE.md`
- update README AI configuration examples to use capability-based placeholders instead of stale model IDs
- update Settings placeholders and vision helper text to avoid prescribing old model names
- mark Phase 1 complete in the lean-refactor roadmap

## Notes
- The local ignored `CLAUDE.md` was reduced to a 58-line agent entrypoint, but it is intentionally not included in this PR because repo policy keeps `CLAUDE.md` out of git.
- No runtime provider migration or behavior change is intended.

## Verification
- `git diff --check`
- `python3 -m compileall -q core modules server.py`
- checked tracked docs/UI for stale model IDs: `gpt-4o-mini`, `dall-e-3`, `gpt-4o`, `claude-haiku-4-5`, `gpt-image-2`
- loaded `frontend/index.html` and verified Settings shows neutral model placeholders

Closes #51
