### PR TITLE
refactor: centralize ai config

### DIFF
--- a/core/ai.py
+++ b/core/ai.py
@@ -1,0 +1,45 @@
+"""Shared AI provider configuration helpers."""
+from dataclasses import dataclass
+
+from openai import OpenAI
+
+from core import config
+
+DEFAULT_BASE_URL = "https://api.ppq.ai/v1"
+DEFAULT_TEXT_MODEL = "gpt-4o-mini"
+DEFAULT_IMAGE_MODEL = "dall-e-3"
+DEFAULT_VISION_MODEL = "gpt-4o"
+
+
+@dataclass(frozen=True)
+class AIConfig:
+    api_key: str
+    base_url: str
+    text_model: str
+    image_model: str
+    vision_model: str
+
+
+def get_ai_config() -> AIConfig:
+    return AIConfig(
+        api_key=config.get("PPQ_API_KEY", ""),
+        base_url=config.get("PPQ_BASE_URL", DEFAULT_BASE_URL),
+        text_model=config.get("PPQ_MODEL", DEFAULT_TEXT_MODEL),
+        image_model=config.get("PPQ_IMAGE_MODEL", DEFAULT_IMAGE_MODEL),
+        vision_model=config.get("PPQ_VISION_MODEL", DEFAULT_VISION_MODEL),
+    )
+
+
+def require_api_key(ai_config: AIConfig | None = None) -> AIConfig:
+    ai_config = ai_config or get_ai_config()
+    if not ai_config.api_key:
+        raise ValueError("PPQ_API_KEY not configured. Add it in Settings.")
+    return ai_config
+
+
+def client(ai_config: AIConfig | None = None, *, timeout: float | None = None) -> OpenAI:
+    ai_config = require_api_key(ai_config)
+    kwargs = {"api_key": ai_config.api_key, "base_url": ai_config.base_url}
+    if timeout is not None:
+        kwargs["timeout"] = timeout
+    return OpenAI(**kwargs)

--- a/docs/roadmap/lean-refactor.md
+++ b/docs/roadmap/lean-refactor.md
@@ -24,7 +24,7 @@ Make Feedme easier for humans and agents to modify while reducing stale docs, AI
 ## Phase status
 
 - Phase 1: Done — [#51](https://github.com/sette7blo/feedme/issues/51)
-- Phase 2: Planned — [#52](https://github.com/sette7blo/feedme/issues/52)
+- Phase 2: Done — [#52](https://github.com/sette7blo/feedme/issues/52)
 - Phase 3: Planned — [#53](https://github.com/sette7blo/feedme/issues/53)
 - Phase 4: Planned — [#54](https://github.com/sette7blo/feedme/issues/54)
 - Phase 5: Planned — [#55](https://github.com/sette7blo/feedme/issues/55)
@@ -46,15 +46,15 @@ Acceptance:
 - [x] No secrets or personal runtime data are added to git.
 
 ### Phase 2 — Centralize AI provider and model config
-Status: Planned
+Status: Done
 GitHub issue: [#52](https://github.com/sette7blo/feedme/issues/52)
 
 Goal: Make AI model/base-url lookup come from one backend source so defaults cannot drift across routes/modules.
 
 Acceptance:
-- [ ] AI model defaults/fallbacks live in one backend place.
-- [ ] Recipe, image, vision, nutrition, and meal-plan AI paths use the shared helper.
-- [ ] Existing `.env` keys continue to work.
+- [x] AI model defaults/fallbacks live in one backend place.
+- [x] Recipe, image, vision, nutrition, and meal-plan AI paths use the shared helper.
+- [x] Existing `.env` keys continue to work.
 
 ### Phase 3 — Reduce AI token and image-cost paths
 Status: Planned

--- a/modules/ai_chef.py
+++ b/modules/ai_chef.py
@@ -7,8 +7,8 @@ import re
 import urllib.request
 from datetime import date
 from pathlib import Path
-from openai import OpenAI
 from core import config
+from core.ai import AIConfig, client as ai_client, require_api_key
 from core.db import db
 from modules.importer import save_recipe_json, slugify
 
@@ -46,21 +46,16 @@ def generate_recipe(prompt: str) -> dict:
     Returns the recipe dict (saved as staged JSON).
     Raises on API error.
     """
-    api_key = config.get("PPQ_API_KEY")
-    if not api_key:
-        raise ValueError("PPQ_API_KEY not configured. Add it in Settings.")
-
-    base_url = config.get("PPQ_BASE_URL", "https://api.ppq.ai/v1")
-    model = config.get("PPQ_MODEL", "gpt-4o-mini")
+    ai_config = require_api_key()
 
     equipment = config.get("EQUIPMENT", "").strip()
     full_prompt = prompt
     if equipment:
         full_prompt += f"\n\nAvailable kitchen equipment: {equipment}. Only suggest techniques and tools that work with this equipment."
 
-    client = OpenAI(api_key=api_key, base_url=base_url)
+    client = ai_client(ai_config)
     response = client.chat.completions.create(
-        model=model,
+        model=ai_config.text_model,
         messages=[
             {"role": "system", "content": SYSTEM_PROMPT},
             {"role": "user", "content": full_prompt}
@@ -83,9 +78,8 @@ def generate_recipe(prompt: str) -> dict:
 
     # Generate image (best-effort — never blocks recipe save)
     slug = recipe_data["slug"]
-    image_model = config.get("PPQ_IMAGE_MODEL", "dall-e-3")
     try:
-        image_path = _generate_image(recipe_data, slug, api_key, base_url, image_model)
+        image_path = _generate_image(recipe_data, slug, ai_config.api_key, ai_config.base_url, ai_config.image_model)
     except Exception:
         image_path = None
     if image_path:
@@ -124,16 +118,11 @@ def extract_recipe_from_text(text: str) -> dict:
     Use AI to extract a structured recipe from pasted raw text.
     Saves as staged. Raises on API error or parse failure.
     """
-    api_key = config.get("PPQ_API_KEY")
-    if not api_key:
-        raise ValueError("PPQ_API_KEY not configured. Add it in Settings.")
+    ai_config = require_api_key()
 
-    base_url = config.get("PPQ_BASE_URL", "https://api.ppq.ai/v1")
-    model = config.get("PPQ_MODEL", "gpt-4o-mini")
-
-    client = OpenAI(api_key=api_key, base_url=base_url)
+    client = ai_client(ai_config)
     response = client.chat.completions.create(
-        model=model,
+        model=ai_config.text_model,
         messages=[
             {"role": "system", "content": EXTRACT_PROMPT},
             {"role": "user", "content": text[:12000]},  # cap to avoid token overflow
@@ -176,7 +165,7 @@ def _generate_image(recipe_data: dict, slug: str, api_key: str, base_url: str, m
         + ". Overhead shot, natural light, styled on a wooden surface, high resolution."
     )
 
-    client = OpenAI(api_key=api_key, base_url=base_url, timeout=60.0)
+    client = ai_client(AIConfig(api_key=api_key, base_url=base_url, text_model="", image_model=model, vision_model=""), timeout=60.0)
     gpt_image_models = {"gpt-image-1", "gpt-image-1.5", "gpt-image-2"}
     kwargs = dict(model=model, prompt=prompt, n=1)
     if model in gpt_image_models:

--- a/modules/camera.py
+++ b/modules/camera.py
@@ -10,8 +10,7 @@ import json
 import re
 from datetime import date
 from pathlib import Path
-from openai import OpenAI
-from core import config
+from core.ai import client as ai_client, require_api_key
 from core.db import db
 from modules.importer import save_recipe_json, slugify
 from modules.ai_chef import _generate_image
@@ -78,12 +77,7 @@ def import_from_images(images: list[tuple[bytes, str]]) -> dict:
     if not images:
         raise ValueError("No images provided.")
 
-    api_key  = config.get("PPQ_API_KEY")
-    if not api_key:
-        raise ValueError("PPQ_API_KEY not configured. Add it in Settings.")
-
-    base_url = config.get("PPQ_BASE_URL", "https://api.ppq.ai/v1")
-    model    = config.get("PPQ_VISION_MODEL", "gpt-4o")
+    ai_config = require_api_key()
 
     multi    = len(images) > 1
     system   = (_MULTI_PROMPT if multi else _SINGLE_PROMPT) + _FIELDS
@@ -107,10 +101,10 @@ def import_from_images(images: list[tuple[bytes, str]]) -> dict:
         })
     content_blocks.append({"type": "text", "text": user_text})
 
-    client = OpenAI(api_key=api_key, base_url=base_url)
+    client = ai_client(ai_config)
 
     response = client.chat.completions.create(
-        model=model,
+        model=ai_config.vision_model,
         messages=[
             {"role": "system", "content": system},
             {"role": "user",   "content": content_blocks},
@@ -132,8 +126,7 @@ def import_from_images(images: list[tuple[bytes, str]]) -> dict:
 
     # Generate a clean food photo from the recipe data (best-effort, never blocks save)
     slug        = recipe_data["slug"]
-    image_model = config.get("PPQ_IMAGE_MODEL", "dall-e-3")
-    image_path  = _generate_image(recipe_data, slug, api_key, base_url, image_model)
+    image_path  = _generate_image(recipe_data, slug, ai_config.api_key, ai_config.base_url, ai_config.image_model)
     if image_path:
         recipe_data["image"] = f"images/{image_path.name}"
 

--- a/modules/meal_plan_ai.py
+++ b/modules/meal_plan_ai.py
@@ -5,7 +5,7 @@ import json
 import re
 from datetime import date, timedelta
 
-import core.config as config
+from core.ai import client as ai_client, require_api_key
 from modules.importer import list_recipes
 from modules.pantry import list_pantry
 
@@ -19,10 +19,9 @@ def generate_week_plan(
     use_pantry: bool,
     prompt: str,
 ) -> dict:
-    api_key  = config.get("PPQ_API_KEY", "")
-    base_url = config.get("PPQ_BASE_URL", "https://api.ppq.ai/v1")
-    model    = config.get("PPQ_MODEL", "gpt-4o-mini")
-    if not api_key:
+    try:
+        ai_config = require_api_key()
+    except ValueError:
         raise ValueError("No AI API key configured")
 
     data    = list_recipes(status="active", page=1, per_page=200)
@@ -88,10 +87,9 @@ def generate_week_plan(
         "Return the raw JSON array with no markdown, no explanation."
     )
 
-    from openai import OpenAI
-    client = OpenAI(api_key=api_key, base_url=base_url)
+    client = ai_client(ai_config)
     resp = client.chat.completions.create(
-        model=model,
+        model=ai_config.text_model,
         messages=[
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": f"Recipe library:\n{json.dumps(recipe_list, ensure_ascii=False)}"},

--- a/server.py
+++ b/server.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from flask import Flask, jsonify, request, send_from_directory
 
 import core.config as config
+from core.ai import client as ai_client, get_ai_config
 from core.schema import init_db
 from modules import importer, ai_chef, rss_fetcher, url_importer, pantry, meal_planner, grocery, camera, cook_log, meal_plan_ai
 
@@ -190,22 +191,22 @@ def toggle_favorite(slug):
 @app.route("/api/ai/test", methods=["GET"])
 def ai_test():
     """Quick connection test — sends a minimal request to the AI provider."""
-    api_key  = config.get("PPQ_API_KEY", "")
-    base_url = config.get("PPQ_BASE_URL", "https://api.ppq.ai/v1")
-    model    = config.get("PPQ_MODEL", "gpt-4o-mini")
-    if not api_key:
+    ai_config = get_ai_config()
+    if not ai_config.api_key:
         return jsonify({"ok": False, "error": "No API key configured"})
-    image_model  = config.get("PPQ_IMAGE_MODEL",  "dall-e-3")
-    vision_model = config.get("PPQ_VISION_MODEL", "gpt-4o")
     try:
-        from openai import OpenAI
-        client = OpenAI(api_key=api_key, base_url=base_url)
+        client = ai_client(ai_config)
         client.chat.completions.create(
-            model=model,
+            model=ai_config.text_model,
             messages=[{"role": "user", "content": "ping"}],
             max_tokens=1,
         )
-        return jsonify({"ok": True, "recipe_model": model, "image_model": image_model, "vision_model": vision_model})
+        return jsonify({
+            "ok": True,
+            "recipe_model": ai_config.text_model,
+            "image_model": ai_config.image_model,
+            "vision_model": ai_config.vision_model,
+        })
     except Exception as e:
         return jsonify({"ok": False, "error": str(e)})
 
@@ -235,7 +236,7 @@ TOPUP_METHODS = {
 
 @app.route("/api/ai/topup", methods=["POST"])
 def ai_topup():
-    api_key = config.get("PPQ_API_KEY", "")
+    api_key = get_ai_config().api_key
     if not api_key:
         return jsonify({"ok": False, "error": "No API key configured"}), 400
     data = request.get_json()
@@ -271,7 +272,7 @@ def ai_topup():
 
 @app.route("/api/ai/topup/status/<invoice_id>", methods=["GET"])
 def ai_topup_status(invoice_id):
-    api_key = config.get("PPQ_API_KEY", "")
+    api_key = get_ai_config().api_key
     if not api_key:
         return jsonify({"ok": False, "error": "No API key configured"}), 400
     try:
@@ -307,10 +308,8 @@ def ai_generate():
 @app.route("/api/recipes/<slug>/regenerate-image", methods=["POST"])
 def recipe_regenerate_image(slug):
     """Regenerate the AI food photo for an existing recipe."""
-    api_key     = config.get("PPQ_API_KEY", "")
-    base_url    = config.get("PPQ_BASE_URL", "https://api.ppq.ai/v1")
-    image_model = config.get("PPQ_IMAGE_MODEL", "dall-e-3")
-    if not api_key:
+    ai_config = get_ai_config()
+    if not ai_config.api_key:
         return jsonify({"error": "No API key configured"}), 400
     recipe = importer.get_recipe(slug)
     if not recipe:
@@ -327,7 +326,7 @@ def recipe_regenerate_image(slug):
             pass
     full.setdefault("name", recipe.get("name", slug))
     try:
-        image_path = ai_chef._generate_image(full, slug, api_key, base_url, image_model)
+        image_path = ai_chef._generate_image(full, slug, ai_config.api_key, ai_config.base_url, ai_config.image_model)
     except Exception as e:
         return jsonify({"error": str(e)}), 500
     # Update JSON and DB with new image path
@@ -474,10 +473,8 @@ def delete_pantry_item(item_id):
 
 @app.route("/api/recipes/<slug>/nutrition", methods=["POST"])
 def estimate_nutrition(slug):
-    api_key  = config.get("PPQ_API_KEY", "")
-    base_url = config.get("PPQ_BASE_URL", "https://api.ppq.ai/v1")
-    model    = config.get("PPQ_MODEL", "gpt-4o-mini")
-    if not api_key:
+    ai_config = get_ai_config()
+    if not ai_config.api_key:
         return jsonify({"error": "No API key configured"}), 400
     recipe = importer.get_recipe(slug)
     if not recipe:
@@ -493,11 +490,10 @@ def estimate_nutrition(slug):
     if not ingredients:
         return jsonify({"error": "Recipe has no ingredients"}), 400
     try:
-        from openai import OpenAI
-        client = OpenAI(api_key=api_key, base_url=base_url)
+        client = ai_client(ai_config)
         recipe_name = full.get("name") or recipe.get("name", slug)
         resp = client.chat.completions.create(
-            model=model,
+            model=ai_config.text_model,
             messages=[
                 {"role": "system", "content": (
                     "You are a nutrition expert. Estimate per-serving nutritional values for a recipe.\n"
@@ -715,13 +711,14 @@ def clear_grocery_all():
 
 @app.route("/api/settings")
 def get_settings():
+    ai_config = get_ai_config()
     return jsonify({
-        "ppq_api_key":      config.get("PPQ_API_KEY", ""),
+        "ppq_api_key":      ai_config.api_key,
         "ppq_credit_id":    config.get("PPQ_CREDIT_ID", ""),
-        "ppq_base_url":     config.get("PPQ_BASE_URL", "https://api.ppq.ai/v1"),
-        "ppq_model":        config.get("PPQ_MODEL", "gpt-4o-mini"),
-        "ppq_image_model":  config.get("PPQ_IMAGE_MODEL", "dall-e-3"),
-        "ppq_vision_model": config.get("PPQ_VISION_MODEL", "gpt-4o"),
+        "ppq_base_url":     ai_config.base_url,
+        "ppq_model":        ai_config.text_model,
+        "ppq_image_model":  ai_config.image_model,
+        "ppq_vision_model": ai_config.vision_model,
         "rss_feeds":           config.get("RSS_FEEDS", ""),
         "rss_auto_fetch_hours": config.get("RSS_AUTO_FETCH_HOURS", "0"),
         "equipment":           config.get("EQUIPMENT", ""),


### PR DESCRIPTION
## Summary
- add `core/ai.py` as the single backend source for AI provider config and OpenAI-compatible client creation
- migrate recipe generation, text extraction, camera import, meal-plan AI, nutrition, image regeneration, and settings/test routes to use the shared helper
- keep existing `PPQ_*` env/settings names and current fallback behavior for compatibility
- mark Phase 2 complete in the lean-refactor roadmap

## Notes
- This does not rename provider settings or change prompts.
- This branch was created from current `main`; PR #58 for Phase 1 is still separate.

## Verification
- `git diff --check`
- `python3 -m compileall -q core modules server.py`
- imported `core.ai` with temporary `PPQ_*` env overrides and verified values round-trip through `get_ai_config()`
- checked that backend modules/routes no longer directly call stale `config.get("PPQ_*", old-model-default)` paths outside `core/ai.py`

Closes #52
