### PR TITLE
refactor: consolidate import normalization

### DIFF
--- a/docs/roadmap/lean-refactor.md
+++ b/docs/roadmap/lean-refactor.md
@@ -27,7 +27,7 @@ Make Feedme easier for humans and agents to modify while reducing stale docs, AI
 - Phase 2: Done — [#52](https://github.com/sette7blo/feedme/issues/52)
 - Phase 3: Done — [#53](https://github.com/sette7blo/feedme/issues/53)
 - Phase 4: Done — [#54](https://github.com/sette7blo/feedme/issues/54)
-- Phase 5: Planned — [#55](https://github.com/sette7blo/feedme/issues/55)
+- Phase 5: Done — [#55](https://github.com/sette7blo/feedme/issues/55)
 - Phase 6: Planned — [#56](https://github.com/sette7blo/feedme/issues/56)
 - Phase 7: Planned — [#57](https://github.com/sette7blo/feedme/issues/57)
 
@@ -79,15 +79,15 @@ Acceptance:
 - [x] No micro-file fragmentation.
 
 ### Phase 5 — Consolidate import and recipe normalization logic
-Status: Planned
+Status: Done
 GitHub issue: [#55](https://github.com/sette7blo/feedme/issues/55)
 
 Goal: Reduce duplicated RSS/URL/text/camera recipe parsing and image handling while preserving import behavior.
 
 Acceptance:
-- [ ] Common recipe normalization lives in one predictable place.
-- [ ] RSS and URL import paths produce equivalent normalized schema fields.
-- [ ] Saving a recipe does not needlessly re-read the just-written JSON when avoidable.
+- [x] Common recipe normalization lives in one predictable place.
+- [x] RSS and URL import paths produce equivalent normalized schema fields.
+- [x] Saving a recipe does not needlessly re-read the just-written JSON when avoidable.
 
 ### Phase 6 — Add batch endpoints for bulk recipe and meal-plan actions
 Status: Planned

--- a/modules/ai_chef.py
+++ b/modules/ai_chef.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from core import config
 from core.ai import AIConfig, client as ai_client, require_api_key
 from core.db import db
+from modules import imports
 from modules.importer import save_recipe_json, slugify
 
 
@@ -63,11 +64,7 @@ def generate_recipe(prompt: str) -> dict:
         temperature=0.7,
         max_tokens=2000
     )
-    content = response.choices[0].message.content.strip()
-
-    # Strip markdown fences if present
-    content = re.sub(r"^```(?:json)?\s*", "", content)
-    content = re.sub(r"\s*```$", "", content)
+    content = imports.strip_json_fences(response.choices[0].message.content)
 
     recipe_data = json.loads(content)
     recipe_data["datePublished"] = date.today().isoformat()
@@ -153,10 +150,7 @@ def extract_recipe_from_text(text: str) -> dict:
         temperature=0.2,
         max_tokens=2000,
     )
-    content = response.choices[0].message.content.strip()
-
-    content = re.sub(r"^```(?:json)?\s*", "", content)
-    content = re.sub(r"\s*```$", "", content)
+    content = imports.strip_json_fences(response.choices[0].message.content)
 
     recipe_data = json.loads(content)
     recipe_data["datePublished"] = date.today().isoformat()

--- a/modules/camera.py
+++ b/modules/camera.py
@@ -7,11 +7,11 @@ Lands in 'staged' status.
 """
 import base64
 import json
-import re
 from datetime import date
 from pathlib import Path
 from core.ai import client as ai_client, require_api_key
 from core.db import db
+from modules import imports
 from modules.importer import save_recipe_json, slugify
 from modules.ai_chef import _generate_image
 
@@ -113,9 +113,7 @@ def import_from_images(images: list[tuple[bytes, str]]) -> dict:
         temperature=0.2,
     )
 
-    content = response.choices[0].message.content.strip()
-    content = re.sub(r"^```(?:json)?\s*", "", content)
-    content = re.sub(r"\s*```$",          "", content)
+    content = imports.strip_json_fences(response.choices[0].message.content)
 
     recipe_data = json.loads(content)
     recipe_data["datePublished"] = date.today().isoformat()

--- a/modules/importer.py
+++ b/modules/importer.py
@@ -14,13 +14,8 @@ def slugify(name: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
 
 
-def parse_recipe_json(path: Path) -> dict | None:
-    try:
-        with open(path) as f:
-            data = json.load(f)
-    except (json.JSONDecodeError, OSError):
-        return None
-
+def recipe_to_row(data: dict, path: Path) -> dict:
+    """Convert in-memory recipe JSON to the SQLite row shape."""
     name = data.get("name", path.stem)
     slug = data.get("slug") or slugify(name)
 
@@ -38,7 +33,6 @@ def parse_recipe_json(path: Path) -> dict | None:
     else:
         tags_json = "[]"
 
-    # Parse duration strings (PT45M → "45 min")
     def parse_duration(val):
         if not val:
             return None
@@ -50,18 +44,20 @@ def parse_recipe_json(path: Path) -> dict | None:
     image = data.get("image", "")
     if isinstance(image, list):
         image = image[0] if image else ""
+    if isinstance(image, dict):
+        image = image.get("url", "")
 
     yield_val = data.get("recipeYield", "")
     if isinstance(yield_val, list):
         yield_val = yield_val[0] if yield_val else ""
-    import re as _re
-    m = _re.search(r'\d+', str(yield_val))
+    m = re.search(r'\d+', str(yield_val))
     servings = int(m.group()) if m else None
 
     def _str_or_first(val):
-        """Return a plain string whether val is a str, list, or None."""
         if isinstance(val, list):
             return val[0] if val else ""
+        if isinstance(val, dict):
+            return val.get("name") or val.get("text") or ""
         return val or ""
 
     return {
@@ -82,6 +78,15 @@ def parse_recipe_json(path: Path) -> dict | None:
         "source_type": data.get("source_type", "manual"),
         "status": data.get("status", "active"),
     }
+
+
+def parse_recipe_json(path: Path) -> dict | None:
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+    return recipe_to_row(data, path)
 
 
 def sync_all() -> dict:
@@ -157,32 +162,36 @@ def save_recipe_json(recipe_data: dict, status: str = "staged") -> Path | None:
     with open(path, "w") as f:
         json.dump(recipe_data, f, indent=2, ensure_ascii=False)
 
-    # Sync this single recipe to DB
-    parsed = parse_recipe_json(path)
-    if parsed:
-        with db() as conn:
-            conn.execute("""
-                INSERT INTO recipes
-                    (slug, name, description, json_path, image_url,
-                     prep_time, cook_time, total_time, servings,
-                     category, cuisine, tags, ingredients,
-                     source_url, source_type, status)
-                VALUES
-                    (:slug, :name, :description, :json_path, :image_url,
-                     :prep_time, :cook_time, :total_time, :servings,
-                     :category, :cuisine, :tags, :ingredients,
-                     :source_url, :source_type, :status)
-                ON CONFLICT(slug) DO UPDATE SET
-                    name=excluded.name,
-                    prep_time=excluded.prep_time,
-                    cook_time=excluded.cook_time,
-                    total_time=excluded.total_time,
-                    servings=excluded.servings,
-                    category=excluded.category,
-                    cuisine=excluded.cuisine,
-                    status=excluded.status,
-                    updated_at=datetime('now')
-            """, parsed)
+    parsed = recipe_to_row(recipe_data, path)
+    with db() as conn:
+        conn.execute("""
+            INSERT INTO recipes
+                (slug, name, description, json_path, image_url,
+                 prep_time, cook_time, total_time, servings,
+                 category, cuisine, tags, ingredients,
+                 source_url, source_type, status)
+            VALUES
+                (:slug, :name, :description, :json_path, :image_url,
+                 :prep_time, :cook_time, :total_time, :servings,
+                 :category, :cuisine, :tags, :ingredients,
+                 :source_url, :source_type, :status)
+            ON CONFLICT(slug) DO UPDATE SET
+                name=excluded.name,
+                description=excluded.description,
+                image_url=excluded.image_url,
+                prep_time=excluded.prep_time,
+                cook_time=excluded.cook_time,
+                total_time=excluded.total_time,
+                servings=excluded.servings,
+                category=excluded.category,
+                cuisine=excluded.cuisine,
+                tags=excluded.tags,
+                ingredients=excluded.ingredients,
+                source_url=excluded.source_url,
+                source_type=excluded.source_type,
+                status=excluded.status,
+                updated_at=datetime('now')
+        """, parsed)
     return path
 
 

--- a/modules/imports.py
+++ b/modules/imports.py
@@ -1,0 +1,278 @@
+"""Shared import and recipe normalization helpers.
+
+This module keeps URL, RSS, text, and camera import paths aligned without
+splitting common parsing into many tiny files.
+"""
+from __future__ import annotations
+
+import gzip
+import json
+import re
+import urllib.error
+import urllib.request
+from datetime import date
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any
+
+from modules.importer import slugify
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+IMAGES_DIR = BASE_DIR / "images"
+
+BROWSER_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/124.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.5",
+}
+
+
+class _LdJsonParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self._in_ld = False
+        self.blocks: list[str] = []
+        self._buf: list[str] = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "script":
+            attrs_d = {k.lower(): v for k, v in attrs}
+            if "ld+json" in attrs_d.get("type", ""):
+                self._in_ld = True
+                self._buf = []
+
+    def handle_endtag(self, tag):
+        if tag == "script" and self._in_ld:
+            self.blocks.append("".join(self._buf))
+            self._in_ld = False
+            self._buf = []
+
+    def handle_data(self, data):
+        if self._in_ld:
+            self._buf.append(data)
+
+
+def strip_json_fences(text: str) -> str:
+    """Remove optional markdown JSON fences around model output."""
+    text = (text or "").strip()
+    text = re.sub(r"^```(?:json)?\s*", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"\s*```$", "", text)
+    return text.strip()
+
+
+def fetch_text(url: str, *, timeout: int = 15, headers: dict[str, str] | None = None) -> str:
+    """Fetch URL content and decode text, supporting gzip responses."""
+    req_headers = {**BROWSER_HEADERS, **(headers or {})}
+    req = urllib.request.Request(url, headers=req_headers)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        raw = resp.read()
+        if resp.headers.get("Content-Encoding") == "gzip":
+            raw = gzip.decompress(raw)
+        charset = "utf-8"
+        content_type = resp.headers.get("Content-Type", "")
+        match = re.search(r"charset=([^\s;]+)", content_type)
+        if match:
+            charset = match.group(1)
+        return raw.decode(charset, errors="replace")
+
+
+def scan_for_recipe(data: Any, *, max_depth: int = 12, _depth: int = 0) -> dict | None:
+    """Recursively scan JSON-LD/Next.js data for a schema.org Recipe object."""
+    if _depth > max_depth:
+        return None
+    if isinstance(data, list):
+        for item in data:
+            result = scan_for_recipe(item, max_depth=max_depth, _depth=_depth + 1)
+            if result:
+                return result
+    elif isinstance(data, dict):
+        types = data.get("@type", "")
+        if isinstance(types, str):
+            types = [types]
+        if "Recipe" in types and (data.get("name") or data.get("recipeIngredient")):
+            return data
+        if "@graph" in data:
+            result = scan_for_recipe(data["@graph"], max_depth=max_depth, _depth=_depth + 1)
+            if result:
+                return result
+        for value in data.values():
+            result = scan_for_recipe(value, max_depth=max_depth, _depth=_depth + 1)
+            if result:
+                return result
+    return None
+
+
+def find_recipe_ld(html: str) -> dict | None:
+    """Search application/ld+json blocks for a schema.org Recipe object."""
+    parser = _LdJsonParser()
+    try:
+        parser.feed(html)
+    except Exception:
+        pass
+    for block in parser.blocks:
+        try:
+            result = scan_for_recipe(json.loads(strip_json_fences(block)))
+            if result:
+                return result
+        except Exception:
+            continue
+    return None
+
+
+def find_recipe_next_data(html: str) -> dict | None:
+    """Search a Next.js __NEXT_DATA__ script for embedded recipe data."""
+    match = re.search(r'<script[^>]+id=["\']__NEXT_DATA__["\'][^>]*>(.*?)</script>', html, re.DOTALL)
+    if not match:
+        return None
+    try:
+        return scan_for_recipe(json.loads(match.group(1)))
+    except Exception:
+        return None
+
+
+def find_recipe_data(html: str) -> dict | None:
+    """Find recipe data in standard JSON-LD or common framework payloads."""
+    return find_recipe_ld(html) or find_recipe_next_data(html)
+
+
+def scalar(value: Any, default: str = "", sep: str = ", ") -> str:
+    """Return a stable string from schema values that may be scalar/list/dict."""
+    if value is None:
+        return default
+    if isinstance(value, list):
+        cleaned = [scalar(v, "", sep) for v in value]
+        cleaned = [v for v in cleaned if v]
+        return sep.join(cleaned) if len(cleaned) > 1 else (cleaned[0] if cleaned else default)
+    if isinstance(value, dict):
+        return str(value.get("name") or value.get("text") or value.get("url") or default)
+    return str(value)
+
+
+def first_scalar(value: Any, default: str = "") -> str:
+    """Return only the first meaningful scalar from list-capable schema fields."""
+    if isinstance(value, list):
+        return first_scalar(value[0], default) if value else default
+    return scalar(value, default)
+
+
+def extract_image_url(image_value: Any) -> str:
+    """Pull a URL string out of common schema.org image shapes."""
+    if not image_value:
+        return ""
+    if isinstance(image_value, str):
+        return image_value
+    if isinstance(image_value, list):
+        for item in image_value:
+            found = extract_image_url(item)
+            if found:
+                return found
+        return ""
+    if isinstance(image_value, dict):
+        return scalar(image_value.get("url") or image_value.get("contentUrl"), "")
+    return ""
+
+
+def normalize_author(author: Any) -> dict:
+    if isinstance(author, list):
+        author = author[0] if author else {}
+    if isinstance(author, dict):
+        return {"@type": author.get("@type", "Person"), "name": scalar(author.get("name"), "")}
+    return {"@type": "Person", "name": scalar(author, "")}
+
+
+def normalize_ingredients(ingredients: Any) -> list[str]:
+    if isinstance(ingredients, str):
+        ingredients = [ingredients]
+    if not isinstance(ingredients, list):
+        return []
+    return [scalar(item).strip() for item in ingredients if scalar(item).strip()]
+
+
+def normalize_instructions(raw_steps: Any) -> list[dict]:
+    """Normalize strings, HowToStep, and nested HowToSection objects to steps."""
+    steps: list[dict] = []
+
+    def add_text(text: Any, name: str = "") -> None:
+        text = scalar(text).strip()
+        if not text:
+            return
+        step = {"@type": "HowToStep", "text": text}
+        if name:
+            step["name"] = name
+        steps.append(step)
+
+    def walk(value: Any) -> None:
+        if not value:
+            return
+        if isinstance(value, str):
+            add_text(value)
+        elif isinstance(value, list):
+            for item in value:
+                walk(item)
+        elif isinstance(value, dict):
+            nested = value.get("itemListElement") or value.get("steps")
+            if nested:
+                walk(nested)
+                return
+            add_text(value.get("text") or value.get("description"), scalar(value.get("name"), ""))
+
+    walk(raw_steps)
+    return steps
+
+
+def normalize_schema_recipe(ld: dict, *, source_url: str = "", source_type: str = "url", rss_item: dict | None = None) -> dict:
+    """Normalize schema.org Recipe data into Feedme's canonical JSON shape."""
+    rss_item = rss_item or {}
+    name = first_scalar(ld.get("name"), rss_item.get("title") or "Imported Recipe").strip()
+    image = extract_image_url(ld.get("image")) or scalar(rss_item.get("image"), "")
+    source = source_url or rss_item.get("link") or scalar(ld.get("url"), "")
+    return {
+        "@context": "https://schema.org",
+        "@type": "Recipe",
+        "name": name,
+        "slug": slugify(name),
+        "description": scalar(ld.get("description"), rss_item.get("description", "")),
+        "image": image,
+        "author": normalize_author(ld.get("author", {})),
+        "datePublished": first_scalar(ld.get("datePublished"), date.today().isoformat()),
+        "prepTime": first_scalar(ld.get("prepTime")),
+        "cookTime": first_scalar(ld.get("cookTime")),
+        "totalTime": first_scalar(ld.get("totalTime")),
+        "recipeYield": first_scalar(ld.get("recipeYield")),
+        "recipeCategory": first_scalar(ld.get("recipeCategory")),
+        "recipeCuisine": first_scalar(ld.get("recipeCuisine")),
+        "keywords": scalar(ld.get("keywords")),
+        "recipeIngredient": normalize_ingredients(ld.get("recipeIngredient", [])),
+        "recipeInstructions": normalize_instructions(ld.get("recipeInstructions", [])),
+        "nutrition": ld.get("nutrition") or {},
+        "source_url": source,
+        "source_type": source_type,
+    }
+
+
+def download_image(image_url: str, slug: str, *, timeout: int = 15, images_dir: Path | None = None) -> Path | None:
+    """Download an external recipe image to images/<slug>.<ext>; best-effort."""
+    if not image_url or not image_url.startswith("http"):
+        return None
+    images_dir = images_dir or IMAGES_DIR
+    images_dir.mkdir(parents=True, exist_ok=True)
+    match = re.search(r"\.(jpg|jpeg|png|webp)(\?|$)", image_url, re.IGNORECASE)
+    suffix = f".{match.group(1).lower()}" if match else ".jpg"
+    if suffix == ".jpeg":
+        suffix = ".jpg"
+    dest = images_dir / f"{slug}{suffix}"
+    try:
+        req = urllib.request.Request(image_url, headers={"User-Agent": "Mozilla/5.0 (compatible; Feedme/1.0)"})
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            dest.write_bytes(resp.read())
+        return dest
+    except Exception:
+        return None
+
+
+def local_image_ref(path: Path | None) -> str | None:
+    return f"images/{path.name}" if path else None

--- a/modules/rss_fetcher.py
+++ b/modules/rss_fetcher.py
@@ -2,16 +2,12 @@
 modules/rss_fetcher.py — Fetch RSS feeds + scrape recipe pages for full JSON-LD data.
 Approach borrowed from mealie-scraper: RSS gives links, page scraping gives recipes.
 """
-import json
 import re
 import time
 import urllib.request
 import xml.etree.ElementTree as ET
-from datetime import date
-from pathlib import Path
+from modules import imports
 from modules.importer import save_recipe_json, slugify
-
-IMAGES_DIR = Path(__file__).parent.parent / "images"
 
 RSS_NS = {
     'media':   'http://search.yahoo.com/mrss/',
@@ -150,26 +146,7 @@ def scrape_recipe_page(url: str) -> dict | None:
     except Exception:
         return None
 
-    pattern = r'<script[^>]*type=["\']application/ld\+json["\'][^>]*>([\s\S]*?)</script>'
-    recipe = None
-    for raw in re.findall(pattern, html):
-        try:
-            data = json.loads(raw.strip())
-        except (json.JSONDecodeError, ValueError):
-            continue
-
-        # Unwrap list, @graph, or plain dict
-        if isinstance(data, list):
-            recipe = next((d for d in data if isinstance(d, dict) and d.get('@type') == 'Recipe'), None)
-        elif isinstance(data, dict):
-            if data.get('@type') == 'Recipe':
-                recipe = data
-            elif isinstance(data.get('@graph'), list):
-                recipe = next((d for d in data['@graph'] if isinstance(d, dict) and d.get('@type') == 'Recipe'), None)
-
-        if recipe:
-            break
-
+    recipe = imports.find_recipe_ld(html)
     if recipe is None:
         return None
 
@@ -289,97 +266,17 @@ def _html_fallback(html: str) -> dict:
 
 def _extract_image(ld_image):
     """Pull a URL string out of the various JSON-LD image formats."""
-    if not ld_image:
-        return None
-    if isinstance(ld_image, str):
-        return ld_image
-    if isinstance(ld_image, list) and ld_image:
-        first = ld_image[0]
-        return first.get('url') if isinstance(first, dict) else first
-    if isinstance(ld_image, dict):
-        return ld_image.get('url')
-    return None
+    return imports.extract_image_url(ld_image) or None
 
 
 def _str(val, sep=', ') -> str:
     """Safely coerce a value that might be a list or None to a string."""
-    if val is None:
-        return ''
-    if isinstance(val, list):
-        return sep.join(str(v) for v in val if v)
-    return str(val)
+    return imports.scalar(val, sep=sep)
 
 
 def normalize_recipe(ld: dict, rss_item: dict) -> dict:
     """Merge JSON-LD data with RSS fallbacks into Feedme's schema.org/Recipe format."""
-
-    # Ingredients
-    ingredients = ld.get('recipeIngredient') or []
-    if isinstance(ingredients, list):
-        ingredients = [i for i in ingredients if isinstance(i, str) and i.strip()]
-
-    # Instructions — handle HowToStep, HowToSection (nested), and plain strings
-    instructions = []
-
-    def _extract_steps(steps):
-        """Recursively extract HowToStep text from steps or HowToSection itemListElement."""
-        if not steps:
-            return
-        if isinstance(steps, str):
-            if steps.strip():
-                instructions.append({'@type': 'HowToStep', 'text': steps.strip()})
-            return
-        if isinstance(steps, dict):
-            steps = [steps]
-        for step in steps:
-            if isinstance(step, str):
-                if step.strip():
-                    instructions.append({'@type': 'HowToStep', 'text': step.strip()})
-            elif isinstance(step, dict):
-                step_type = step.get('@type', '')
-                if step_type == 'HowToSection' or 'itemListElement' in step:
-                    # Section: recurse into its nested steps
-                    _extract_steps(step.get('itemListElement', []))
-                else:
-                    # Regular HowToStep
-                    text = step.get('text') or ''
-                    if text.strip():
-                        instructions.append({'@type': 'HowToStep', 'text': text.strip(),
-                                             'name': step.get('name', '')})
-
-    _extract_steps(ld.get('recipeInstructions') or [])
-
-    # Image: prefer JSON-LD, fall back to RSS feed image
-    image_url = _extract_image(ld.get('image')) or rss_item.get('image')
-
-    # Author
-    author = ld.get('author', {})
-    author_name = author.get('name', '') if isinstance(author, dict) else str(author)
-
-    name = (_str(ld.get('name')) or rss_item['title']).strip()
-
-    return {
-        '@context':           'https://schema.org',
-        '@type':              'Recipe',
-        'name':               name,
-        'slug':               slugify(name),
-        'description':        _str(ld.get('description')) or rss_item.get('description', ''),
-        'image':              image_url,
-        'author':             {'@type': 'Person', 'name': author_name},
-        'datePublished':      _str(ld.get('datePublished')) or date.today().isoformat(),
-        'prepTime':           _str(ld.get('prepTime')),
-        'cookTime':           _str(ld.get('cookTime')),
-        'totalTime':          _str(ld.get('totalTime')),
-        'recipeYield':        _str(ld.get('recipeYield')),
-        'recipeCategory':     _str(ld.get('recipeCategory')),
-        'recipeCuisine':      _str(ld.get('recipeCuisine')),
-        'keywords':           _str(ld.get('keywords')),
-        'recipeIngredient':   ingredients,
-        'recipeInstructions': instructions,
-        'nutrition':          ld.get('nutrition') or {},
-        'source_url':         rss_item.get('link', '') or _str(ld.get('url')),
-        'source_type':        'rss',
-    }
+    return imports.normalize_schema_recipe(ld, rss_item=rss_item, source_type='rss')
 
 
 def _stub_recipe(rss_item: dict) -> dict:
@@ -407,26 +304,7 @@ def download_image(image_url: str, slug: str) -> str | None:
     Download image from URL, save to images/<slug>.<ext>.
     Returns local path string like 'images/slug.jpg', or None on failure.
     """
-    if not image_url or not image_url.startswith('http'):
-        return None
-    IMAGES_DIR.mkdir(parents=True, exist_ok=True)
-
-    # Determine extension
-    ext = 'jpg'
-    url_path = image_url.split('?')[0].lower()
-    for candidate in ('webp', 'png', 'jpeg', 'jpg'):
-        if url_path.endswith(f'.{candidate}'):
-            ext = 'jpg' if candidate == 'jpeg' else candidate
-            break
-
-    local_path = IMAGES_DIR / f"{slug}.{ext}"
-    try:
-        req = urllib.request.Request(image_url, headers=HEADERS)
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            local_path.write_bytes(resp.read())
-        return f"images/{slug}.{ext}"
-    except Exception:
-        return None
+    return imports.local_image_ref(imports.download_image(image_url, slug))
 
 
 # ── Public API ────────────────────────────────────────────────────────────────

--- a/modules/url_importer.py
+++ b/modules/url_importer.py
@@ -1,168 +1,11 @@
 """
 modules/url_importer.py — URL → schema.org/Recipe JSON
 Fetches a recipe page, extracts JSON-LD Recipe data, saves as staged.
-Uses only stdlib (urllib, html.parser, gzip) — no extra dependencies.
 """
-import gzip
-import json
-import re
-import urllib.request
 import urllib.error
-from html.parser import HTMLParser
-from datetime import date
-from pathlib import Path
-from modules.importer import save_recipe_json, slugify
 
-IMAGES_DIR = Path(__file__).parent.parent / "images"
-
-
-class _LdJsonParser(HTMLParser):
-    """Extract all <script type="application/ld+json"> blocks from HTML."""
-
-    def __init__(self):
-        super().__init__()
-        self._in_ld = False
-        self.blocks = []
-        self._buf = []
-
-    def handle_starttag(self, tag, attrs):
-        if tag == "script":
-            attrs_d = {k.lower(): v for k, v in attrs}
-            if "ld+json" in attrs_d.get("type", ""):
-                self._in_ld = True
-                self._buf = []
-
-    def handle_endtag(self, tag):
-        if tag == "script" and self._in_ld:
-            self.blocks.append("".join(self._buf))
-            self._in_ld = False
-            self._buf = []
-
-    def handle_data(self, data):
-        if self._in_ld:
-            self._buf.append(data)
-
-
-def _scan_for_recipe(data) -> dict | None:
-    """Recursively scan a JSON-LD value for a Recipe object."""
-    if isinstance(data, list):
-        for item in data:
-            r = _scan_for_recipe(item)
-            if r:
-                return r
-    elif isinstance(data, dict):
-        types = data.get("@type", "")
-        if isinstance(types, str):
-            types = [types]
-        if "Recipe" in types:
-            return data
-        if "@graph" in data:
-            return _scan_for_recipe(data["@graph"])
-    return None
-
-
-def _find_recipe_ld(html: str) -> dict | None:
-    """Search JSON-LD blocks for a schema.org Recipe object."""
-    parser = _LdJsonParser()
-    try:
-        parser.feed(html)
-    except Exception:
-        pass
-    for block in parser.blocks:
-        try:
-            result = _scan_for_recipe(json.loads(block))
-            if result:
-                return result
-        except Exception:
-            continue
-    return None
-
-
-def _find_recipe_next_data(html: str) -> dict | None:
-    """Fallback: scan __NEXT_DATA__ script tag (Next.js sites)."""
-    m = re.search(r'<script[^>]+id=["\']__NEXT_DATA__["\'][^>]*>(.*?)</script>', html, re.DOTALL)
-    if not m:
-        return None
-    try:
-        return _deep_scan(json.loads(m.group(1)))
-    except Exception:
-        return None
-
-
-def _deep_scan(obj, depth=0) -> dict | None:
-    if depth > 12:
-        return None
-    if isinstance(obj, dict):
-        types = obj.get("@type", "")
-        if isinstance(types, str):
-            types = [types]
-        if "Recipe" in types and "name" in obj:
-            return obj
-        for v in obj.values():
-            r = _deep_scan(v, depth + 1)
-            if r:
-                return r
-    elif isinstance(obj, list):
-        for item in obj:
-            r = _deep_scan(item, depth + 1)
-            if r:
-                return r
-    return None
-
-
-def _normalize(ld: dict, source_url: str) -> dict:
-    name = ld.get("name", "Imported Recipe")
-    if isinstance(name, list):
-        name = name[0] if name else "Imported Recipe"
-
-    raw_steps = ld.get("recipeInstructions", [])
-    if isinstance(raw_steps, str):
-        raw_steps = [raw_steps]
-    steps = []
-    for s in raw_steps:
-        if isinstance(s, str) and s.strip():
-            steps.append({"@type": "HowToStep", "text": s.strip()})
-        elif isinstance(s, dict):
-            text = s.get("text", s.get("description", "")).strip()
-            if text:
-                steps.append({"@type": "HowToStep", "text": text})
-
-    image = ld.get("image", "")
-    if isinstance(image, list):
-        image = image[0] if image else ""
-    if isinstance(image, dict):
-        image = image.get("url", "")
-
-    author = ld.get("author", {"@type": "Person", "name": "Unknown"})
-    if isinstance(author, list):
-        author = author[0] if author else {"@type": "Person", "name": "Unknown"}
-
-    recipe_yield = ld.get("recipeYield", "")
-    if isinstance(recipe_yield, list):
-        recipe_yield = recipe_yield[0] if recipe_yield else ""
-
-    return {
-        "@context": "https://schema.org",
-        "@type": "Recipe",
-        "name": name,
-        "slug": slugify(name),
-        "description": ld.get("description", ""),
-        "image": image,
-        "author": author,
-        "datePublished": date.today().isoformat(),
-        "prepTime": ld.get("prepTime", ""),
-        "cookTime": ld.get("cookTime", ""),
-        "totalTime": ld.get("totalTime", ""),
-        "recipeYield": recipe_yield,
-        "recipeCategory": ld.get("recipeCategory", ""),
-        "recipeCuisine": ld.get("recipeCuisine", ""),
-        "keywords": ld.get("keywords", ""),
-        "recipeIngredient": ld.get("recipeIngredient", []),
-        "recipeInstructions": steps,
-        "nutrition": ld.get("nutrition", {}),
-        "source_url": source_url,
-        "source_type": "url",
-    }
+from modules import imports
+from modules.importer import save_recipe_json
 
 
 def import_from_url(url: str) -> dict:
@@ -171,26 +14,7 @@ def import_from_url(url: str) -> dict:
     Raises ValueError with a user-readable message on failure.
     """
     try:
-        req = urllib.request.Request(
-            url,
-            headers={
-                "User-Agent": (
-                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-                    "AppleWebKit/537.36 (KHTML, like Gecko) "
-                    "Chrome/124.0.0.0 Safari/537.36"
-                ),
-                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-                "Accept-Language": "en-US,en;q=0.5",
-                "Accept-Encoding": "gzip, deflate",
-            },
-        )
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            raw = resp.read()
-            if resp.headers.get("Content-Encoding") == "gzip":
-                raw = gzip.decompress(raw)
-            ct = resp.headers.get("Content-Type", "")
-            m = re.search(r"charset=([^\s;]+)", ct)
-            html = raw.decode(m.group(1) if m else "utf-8", errors="replace")
+        html = imports.fetch_text(url, timeout=15, headers={"Accept-Encoding": "gzip, deflate"})
     except urllib.error.HTTPError as exc:
         if exc.code == 403:
             raise ValueError(
@@ -201,39 +25,19 @@ def import_from_url(url: str) -> dict:
     except urllib.error.URLError as exc:
         raise ValueError(f"Could not fetch URL: {exc}") from exc
 
-    ld = _find_recipe_ld(html) or _find_recipe_next_data(html)
+    ld = imports.find_recipe_data(html)
     if not ld:
         raise ValueError(
             "No schema.org/Recipe found at this URL. "
             "The site may not use standard markup — try the Import from Image option instead."
         )
 
-    recipe = _normalize(ld, url)
+    recipe = imports.normalize_schema_recipe(ld, source_url=url, source_type="url")
 
-    # Download image locally (best-effort — never blocks recipe save)
-    remote_image = recipe.get("image", "")
-    if remote_image and remote_image.startswith("http"):
-        local_path = _download_image(remote_image, recipe["slug"])
-        if local_path:
-            recipe["image"] = f"images/{local_path.name}"
+    local_path = imports.download_image(recipe.get("image", ""), recipe["slug"], timeout=10)
+    local_ref = imports.local_image_ref(local_path)
+    if local_ref:
+        recipe["image"] = local_ref
 
     save_recipe_json(recipe, status="staged")
     return recipe
-
-
-def _download_image(image_url: str, slug: str) -> Path | None:
-    IMAGES_DIR.mkdir(exist_ok=True)
-    # Guess extension from URL, default to .jpg
-    ext = re.search(r"\.(jpg|jpeg|png|webp)(\?|$)", image_url, re.IGNORECASE)
-    suffix = f".{ext.group(1).lower()}" if ext else ".jpg"
-    dest = IMAGES_DIR / f"{slug}{suffix}"
-    try:
-        req = urllib.request.Request(
-            image_url,
-            headers={"User-Agent": "Mozilla/5.0 (compatible; Feedme/1.0)"},
-        )
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            dest.write_bytes(resp.read())
-        return dest
-    except Exception:
-        return None

--- a/tests/test_imports_normalization.py
+++ b/tests/test_imports_normalization.py
@@ -1,0 +1,74 @@
+import json
+import unittest
+
+from modules import imports
+
+
+class ImportNormalizationTests(unittest.TestCase):
+    def test_strip_json_fences_accepts_markdown_wrapped_json(self):
+        wrapped = "```json\n{\"name\": \"Soup\"}\n```"
+        self.assertEqual(imports.strip_json_fences(wrapped), '{"name": "Soup"}')
+
+    def test_find_recipe_data_finds_recipe_in_ld_json_graph_and_next_data(self):
+        ld_html = """
+        <html><script type="application/ld+json">
+        {"@graph":[{"@type":"WebPage"},{"@type":["Recipe","Article"],"name":"Pasta"}]}
+        </script></html>
+        """
+        self.assertEqual(imports.find_recipe_data(ld_html)["name"], "Pasta")
+
+        next_html = """
+        <script id="__NEXT_DATA__" type="application/json">
+        {"props":{"pageProps":{"recipe":{"@type":"Recipe","name":"Cake"}}}}
+        </script>
+        """
+        self.assertEqual(imports.find_recipe_data(next_html)["name"], "Cake")
+
+    def test_normalize_schema_recipe_matches_url_and_rss_shape(self):
+        ld = {
+            "@type": "Recipe",
+            "name": ["Pasta"],
+            "description": ["Fast dinner"],
+            "image": [{"url": "https://example.test/pasta.webp"}],
+            "author": [{"@type": "Person", "name": "Ada"}],
+            "recipeYield": ["4 servings"],
+            "recipeCategory": ["Dinner"],
+            "recipeCuisine": ["Italian"],
+            "keywords": ["quick", "pasta"],
+            "recipeIngredient": ["200g pasta", "1 cup sauce", ""],
+            "recipeInstructions": [
+                {"@type": "HowToSection", "itemListElement": [
+                    {"@type": "HowToStep", "text": "Boil pasta."},
+                    "Toss with sauce.",
+                ]}
+            ],
+            "nutrition": {"calories": "400"},
+        }
+        rss_item = {"title": "Fallback", "link": "https://example.test/rss", "description": "rss desc"}
+        url_recipe = imports.normalize_schema_recipe(ld, source_url="https://example.test/url", source_type="url")
+        rss_recipe = imports.normalize_schema_recipe(ld, rss_item=rss_item, source_type="rss")
+
+        for recipe in (url_recipe, rss_recipe):
+            self.assertEqual(recipe["name"], "Pasta")
+            self.assertEqual(recipe["slug"], "pasta")
+            self.assertEqual(recipe["image"], "https://example.test/pasta.webp")
+            self.assertEqual(recipe["author"], {"@type": "Person", "name": "Ada"})
+            self.assertEqual(recipe["recipeIngredient"], ["200g pasta", "1 cup sauce"])
+            self.assertEqual(
+                [step["text"] for step in recipe["recipeInstructions"]],
+                ["Boil pasta.", "Toss with sauce."],
+            )
+            self.assertEqual(recipe["recipeYield"], "4 servings")
+            self.assertEqual(recipe["recipeCategory"], "Dinner")
+            self.assertEqual(recipe["recipeCuisine"], "Italian")
+            self.assertEqual(recipe["keywords"], "quick, pasta")
+            self.assertEqual(recipe["nutrition"], {"calories": "400"})
+
+        self.assertEqual(url_recipe["source_url"], "https://example.test/url")
+        self.assertEqual(url_recipe["source_type"], "url")
+        self.assertEqual(rss_recipe["source_url"], "https://example.test/rss")
+        self.assertEqual(rss_recipe["source_type"], "rss")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a broad modules/imports.py helper for shared JSON fence stripping, JSON-LD/Next.js recipe discovery, schema normalization, instruction normalization, image URL extraction, and image download/storage.
- Update URL, RSS, text, and camera import paths to use shared import helpers where behavior overlaps.
- Update importer.save_recipe_json to derive the SQLite row from the just-written recipe data instead of re-reading the JSON file.
- Mark Phase 5 done in the lean-refactor roadmap.
- Add unittest coverage for shared import normalization behavior and URL/RSS shape equivalence.

## Test Plan
- [x] python3 -m unittest discover -s tests -v
- [x] python3 -m compileall -q core modules server.py
- [x] Flask test-client smoke for /api/settings and /api/import/rss/stats via uv run
- [x] Run recipe sync against a temporary writable DB: {'synced': 78, 'errors': 0, 'total': 78}
- [x] git diff --check
- [x] docker build -t feedme-phase5-check .
- [x] docker run smoke for /api/settings and /api/import/rss/stats

Closes #55