### PR TITLE
refactor: add batch action endpoints

### DIFF
--- a/docs/roadmap/lean-refactor.md
+++ b/docs/roadmap/lean-refactor.md
@@ -28,7 +28,7 @@ Make Feedme easier for humans and agents to modify while reducing stale docs, AI
 - Phase 3: Done — [#53](https://github.com/sette7blo/feedme/issues/53)
 - Phase 4: Done — [#54](https://github.com/sette7blo/feedme/issues/54)
 - Phase 5: Done — [#55](https://github.com/sette7blo/feedme/issues/55)
-- Phase 6: Planned — [#56](https://github.com/sette7blo/feedme/issues/56)
+- Phase 6: Done — [#56](https://github.com/sette7blo/feedme/issues/56)
 - Phase 7: Planned — [#57](https://github.com/sette7blo/feedme/issues/57)
 
 ## Phases
@@ -90,15 +90,15 @@ Acceptance:
 - [x] Saving a recipe does not needlessly re-read the just-written JSON when avoidable.
 
 ### Phase 6 — Add batch endpoints for bulk recipe and meal-plan actions
-Status: Planned
+Status: Done
 GitHub issue: [#56](https://github.com/sette7blo/feedme/issues/56)
 
 Goal: Replace frontend request storms with explicit batch APIs that are easier to reason about and recover from.
 
 Acceptance:
-- [ ] Bulk frontend actions use one request per bulk operation.
-- [ ] API returns enough detail to show success/failure counts.
-- [ ] Existing single-item endpoints still work.
+- [x] Bulk frontend actions use one request per bulk operation.
+- [x] API returns enough detail to show success/failure counts.
+- [x] Existing single-item endpoints still work.
 
 ### Phase 7 — Lean frontend rendering helpers without adding a build step
 Status: Planned

--- a/frontend/planner.js
+++ b/frontend/planner.js
@@ -327,12 +327,12 @@ async function acceptWeekPlan() {
   const btn = document.getElementById('wplan-accept-btn');
   btn.disabled = true; btn.textContent = 'Saving…';
   try {
-    await Promise.all(_wplanPlan.map(e => apiPost('/api/mealplan', {
+    const result = await apiPost('/api/mealplan/batch', { slots: _wplanPlan.map(e => ({
       date: e.date, meal_type: e.meal_type, recipe_slug: e.recipe_slug
-    })));
+    })) });
     closeWeekPlanModal();
     loadPlanner();
-    toast('Week plan added to planner', 'ok');
+    toast(result.failed ? `Week plan partly added · ${result.failed} failed` : 'Week plan added to planner', result.failed ? 'err' : 'ok');
   } catch(e) {
     toast(e.message || 'Could not save plan', 'err');
   } finally {
@@ -402,13 +402,14 @@ async function applyTemplate(id) {
     if (!tmpl) { toast('Template not found', 'err'); return; }
     const slots = typeof tmpl.slots === 'string' ? JSON.parse(tmpl.slots) : (tmpl.slots || []);
     const _wb = mondayOf(new Date()); _wb.setDate(_wb.getDate()+weekOffset*7); const start = new Date(isoDate(_wb) + 'T00:00:00');
-    await Promise.all(slots.map(s => {
+    const slotsToAdd = slots.map(s => {
       const d = new Date(start.getTime() + s.date_offset * 86400000);
       const dateStr = d.toISOString().slice(0,10);
-      return apiPost('/api/mealplan', { date: dateStr, meal_type: s.meal_type, recipe_slug: s.recipe_slug });
-    }));
+      return { date: dateStr, meal_type: s.meal_type, recipe_slug: s.recipe_slug };
+    });
+    const result = await apiPost('/api/mealplan/batch', { slots: slotsToAdd });
     loadPlanner();
-    toast('Template loaded', 'ok');
+    toast(result.failed ? `Template partly loaded · ${result.failed} failed` : 'Template loaded', result.failed ? 'err' : 'ok');
   } catch(e) { toast(e.message, 'err'); }
 }
 

--- a/frontend/recipes.js
+++ b/frontend/recipes.js
@@ -997,10 +997,11 @@ async function emptyTrash() {
   if (!trashedData.length) return;
   if (!confirm(`Permanently delete all ${trashedData.length} recipe${trashedData.length===1?'':'s'} in trash? This cannot be undone.`)) return;
   try {
-    await Promise.all(trashedData.map(r => apiDel(`/api/recipes/permanent/${r.slug}`)));
-    trashedData = [];
+    const result = await _batchRecipeAction('permanent_delete', trashedData.map(r => r.slug));
+    const okSlugs = result.results.filter(r => r.ok).map(r => r.slug);
+    trashedData = trashedData.filter(r => !okSlugs.includes(r.slug));
     renderTrashed();
-    toast('Trash emptied', 'ok');
+    toast(_batchMessage(result, 'Trash emptied'), 'ok');
   } catch(e) { toast(e.message, 'err'); }
 }
 
@@ -1087,16 +1088,26 @@ function deselectAll() {
   _updateBulkBar();
 }
 
+function _batchMessage(result, label) {
+  if (!result || !result.failed) return label;
+  return `${label} · ${result.failed} failed`;
+}
+
+async function _batchRecipeAction(action, slugs) {
+  return apiPost('/api/recipes/batch', { action, slugs });
+}
+
 async function bulkFavorite() {
   const slugs = [..._selected];
   if (!slugs.length) return;
   try {
-    await Promise.all(slugs.map(slug => apiPost(`/api/recipes/favorite/${slug}`)));
-    slugs.forEach(slug => {
+    const result = await _batchRecipeAction('favorite', slugs);
+    const okSlugs = result.results.filter(r => r.ok).map(r => r.slug);
+    okSlugs.forEach(slug => {
       const r = recipesData.find(r => r.slug === slug);
       if (r) r.favorited = 1;
     });
-    toast(`${slugs.length} recipe${slugs.length!==1?'s':''} added to favorites`);
+    toast(_batchMessage(result, `${result.ok} recipe${result.ok!==1?'s':''} added to favorites`));
     exitSelectMode();
   } catch(e) { toast(e.message, 'err'); }
 }
@@ -1105,13 +1116,14 @@ async function bulkUnfavorite() {
   const slugs = [..._selected];
   if (!slugs.length) return;
   try {
-    await Promise.all(slugs.map(slug => apiPost(`/api/recipes/favorite/${slug}`)));
-    favoritesData = favoritesData.filter(r => !slugs.includes(r.slug));
-    slugs.forEach(slug => {
+    const result = await _batchRecipeAction('unfavorite', slugs);
+    const okSlugs = result.results.filter(r => r.ok).map(r => r.slug);
+    favoritesData = favoritesData.filter(r => !okSlugs.includes(r.slug));
+    okSlugs.forEach(slug => {
       const r = recipesData.find(r => r.slug === slug);
       if (r) r.favorited = 0;
     });
-    toast(`${slugs.length} recipe${slugs.length!==1?'s':''} removed from favorites`);
+    toast(_batchMessage(result, `${result.ok} recipe${result.ok!==1?'s':''} removed from favorites`));
     exitSelectMode();
   } catch(e) { toast(e.message, 'err'); }
 }
@@ -1121,10 +1133,11 @@ async function bulkTrash() {
   if (!slugs.length) return;
   if (!confirm(`Move ${slugs.length} recipe${slugs.length!==1?'s':''} to trash?`)) return;
   try {
-    await Promise.all(slugs.map(slug => apiDel(`/api/recipes/${slug}`)));
-    recipesData   = recipesData.filter(r => !slugs.includes(r.slug));
-    favoritesData = favoritesData.filter(r => !slugs.includes(r.slug));
-    toast(`${slugs.length} recipe${slugs.length!==1?'s':''} moved to trash`);
+    const result = await _batchRecipeAction('trash', slugs);
+    const okSlugs = result.results.filter(r => r.ok).map(r => r.slug);
+    recipesData   = recipesData.filter(r => !okSlugs.includes(r.slug));
+    favoritesData = favoritesData.filter(r => !okSlugs.includes(r.slug));
+    toast(_batchMessage(result, `${result.ok} recipe${result.ok!==1?'s':''} moved to trash`));
     exitSelectMode();
     if (currentTab === 'recipes') _loadSubContent('recipes', _activeSubTab('recipes'));
   } catch(e) { toast(e.message, 'err'); }
@@ -1134,10 +1147,11 @@ async function bulkKeep() {
   const slugs = [..._selected];
   if (!slugs.length) return;
   try {
-    await Promise.all(slugs.map(slug => apiPost(`/api/recipes/approve/${slug}`)));
-    stagedData = stagedData.filter(r => !slugs.includes(r.slug));
+    const result = await _batchRecipeAction('approve', slugs);
+    const okSlugs = result.results.filter(r => r.ok).map(r => r.slug);
+    stagedData = stagedData.filter(r => !okSlugs.includes(r.slug));
     updateStageBadge(stagedData.length);
-    toast(`${slugs.length} recipe${slugs.length!==1?'s':''} approved`);
+    toast(_batchMessage(result, `${result.ok} recipe${result.ok!==1?'s':''} approved`));
     exitSelectMode();
   } catch(e) { toast(e.message, 'err'); }
 }
@@ -1147,10 +1161,11 @@ async function bulkTrashStaged() {
   if (!slugs.length) return;
   if (!confirm(`Discard ${slugs.length} recipe${slugs.length!==1?'s':''}?`)) return;
   try {
-    await Promise.all(slugs.map(slug => apiDel(`/api/recipes/${slug}`)));
-    stagedData = stagedData.filter(r => !slugs.includes(r.slug));
+    const result = await _batchRecipeAction('discard', slugs);
+    const okSlugs = result.results.filter(r => r.ok).map(r => r.slug);
+    stagedData = stagedData.filter(r => !okSlugs.includes(r.slug));
     updateStageBadge(stagedData.length);
-    toast(`${slugs.length} recipe${slugs.length!==1?'s':''} discarded`);
+    toast(_batchMessage(result, `${result.ok} recipe${result.ok!==1?'s':''} discarded`));
     exitSelectMode();
   } catch(e) { toast(e.message, 'err'); }
 }

--- a/modules/importer.py
+++ b/modules/importer.py
@@ -10,6 +10,14 @@ from core.db import db, rows_to_list, row_to_dict
 RECIPES_DIR = Path(__file__).parent.parent / "recipes"
 
 
+def _base_dir() -> Path:
+    return RECIPES_DIR.parent
+
+
+def _stored_path(rel_path: str) -> Path:
+    return _base_dir() / rel_path
+
+
 def slugify(name: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
 
@@ -195,6 +203,46 @@ def save_recipe_json(recipe_data: dict, status: str = "staged") -> Path | None:
     return path
 
 
+def _batch_summary(results: list[dict]) -> dict:
+    ok_count = sum(1 for r in results if r.get("ok"))
+    return {
+        "ok": ok_count,
+        "failed": len(results) - ok_count,
+        "total": len(results),
+        "results": results,
+    }
+
+
+def batch_recipe_action(action: str, slugs: list[str]) -> dict:
+    """Apply a supported recipe action to each slug and return per-item results."""
+    handlers = {
+        "favorite": lambda slug: set_favorite(slug, True),
+        "unfavorite": lambda slug: set_favorite(slug, False),
+        "trash": trash_recipe,
+        "discard": trash_recipe,
+        "approve": approve_recipe,
+        "restore": restore_recipe,
+        "permanent_delete": permanent_delete_recipe,
+    }
+    if action not in handlers:
+        raise ValueError(f"Unsupported batch action: {action}")
+
+    results = []
+    for slug in slugs or []:
+        try:
+            result = handlers[action](slug)
+            success = bool(result)
+            item = {"slug": slug, "ok": success}
+            if isinstance(result, dict):
+                item.update(result)
+            elif not success:
+                item["error"] = "not found or not valid for action"
+            results.append(item)
+        except Exception as exc:
+            results.append({"slug": slug, "ok": False, "error": str(exc)})
+    return _batch_summary(results)
+
+
 def restore_recipe(slug: str) -> bool:
     """Restore a trashed recipe back to active, rebuilding JSON from DB if missing."""
     with db() as conn:
@@ -203,7 +251,7 @@ def restore_recipe(slug: str) -> bool:
             return False
 
         r = dict(row)
-        json_path = Path(__file__).parent.parent / r["json_path"]
+        json_path = _stored_path(r["json_path"])
 
         if not json_path.exists():
             # Rebuild JSON from DB metadata (instructions will be empty)
@@ -249,7 +297,7 @@ def update_recipe(slug: str, data: dict) -> dict | None:
     if not row:
         return None
 
-    path = Path(__file__).parent.parent / row["json_path"]
+    path = _stored_path(row["json_path"])
     existing = {}
     if path.exists():
         with open(path) as f:
@@ -283,7 +331,7 @@ def get_recipe(slug: str) -> dict | None:
             return None
         r = row_to_dict(row)
         # Load full JSON from file for complete data
-        json_path = Path(__file__).parent.parent / r["json_path"]
+        json_path = _stored_path(r["json_path"])
         if json_path.exists():
             with open(json_path) as f:
                 full = json.load(f)
@@ -325,19 +373,30 @@ def list_recipes(status: str = "active", page: int = 1, per_page: int = 24) -> d
     }
 
 
+def set_favorite(slug: str, favorited: bool) -> dict | None:
+    """Set the favorited flag on an active recipe. Returns {favorited: bool}."""
+    with db() as conn:
+        row = conn.execute(
+            "SELECT 1 FROM recipes WHERE slug=? AND status='active'", (slug,)
+        ).fetchone()
+        if not row:
+            return None
+        new_val = 1 if favorited else 0
+        conn.execute(
+            "UPDATE recipes SET favorited=?, updated_at=datetime('now') WHERE slug=?", (new_val, slug)
+        )
+    return {"favorited": bool(new_val)}
+
+
 def toggle_favorite(slug: str) -> dict:
     """Toggle the favorited flag on an active recipe. Returns {favorited: bool}."""
     with db() as conn:
         row = conn.execute(
             "SELECT favorited FROM recipes WHERE slug=? AND status='active'", (slug,)
         ).fetchone()
-        if not row:
-            return None
-        new_val = 0 if row["favorited"] else 1
-        conn.execute(
-            "UPDATE recipes SET favorited=? WHERE slug=?", (new_val, slug)
-        )
-    return {"favorited": bool(new_val)}
+    if not row:
+        return None
+    return set_favorite(slug, not bool(row["favorited"]))
 
 
 def approve_recipe(slug: str) -> bool:
@@ -350,7 +409,7 @@ def approve_recipe(slug: str) -> bool:
         # Also update JSON file
         row = conn.execute("SELECT json_path FROM recipes WHERE slug=?", (slug,)).fetchone()
         if row:
-            path = Path(__file__).parent.parent / row["json_path"]
+            path = _stored_path(row["json_path"])
             if path.exists():
                 with open(path) as f:
                     data = json.load(f)
@@ -369,7 +428,7 @@ def permanent_delete_recipe(slug: str) -> bool:
         if not row:
             return False
 
-        base = Path(__file__).parent.parent
+        base = _base_dir()
 
         # Delete JSON file
         json_path = base / row["json_path"]
@@ -401,11 +460,11 @@ def trash_recipe(slug: str) -> bool:
 
         if row["status"] == "staged":
             # Hard-delete staged recipes (never approved, safe to remove)
-            json_path = Path(__file__).parent.parent / row["json_path"]
+            json_path = _stored_path(row["json_path"])
             if json_path.exists():
                 json_path.unlink()
 
-            base = Path(__file__).parent.parent
+            base = _base_dir()
             for img_path in {
                 base / "images" / f"{slug}.jpg",
                 base / "images" / f"{slug}.png",
@@ -422,7 +481,7 @@ def trash_recipe(slug: str) -> bool:
                 "UPDATE recipes SET status='trashed', updated_at=datetime('now') WHERE slug=?",
                 (slug,)
             )
-            json_path = Path(__file__).parent.parent / row["json_path"]
+            json_path = _stored_path(row["json_path"])
             if json_path.exists():
                 with open(json_path) as f:
                     data = json.load(f)

--- a/modules/meal_planner.py
+++ b/modules/meal_planner.py
@@ -257,6 +257,31 @@ def add_to_plan(date: str, meal_type: str, recipe_slug: str, servings: int = Non
     return row_to_dict(row)
 
 
+def add_slots_batch(slots: list[dict]) -> dict:
+    """Add many meal-plan slots, returning per-item success/failure details."""
+    results = []
+    for idx, slot in enumerate(slots or []):
+        try:
+            entry = add_to_plan(
+                date=slot["date"],
+                meal_type=slot["meal_type"],
+                recipe_slug=slot["recipe_slug"],
+                servings=slot.get("servings"),
+            )
+            results.append({"index": idx, "ok": True, "entry": entry})
+        except Exception as exc:
+            results.append({
+                "index": idx,
+                "ok": False,
+                "date": slot.get("date"),
+                "meal_type": slot.get("meal_type"),
+                "recipe_slug": slot.get("recipe_slug"),
+                "error": str(exc),
+            })
+    ok_count = sum(1 for r in results if r.get("ok"))
+    return {"ok": ok_count, "failed": len(results) - ok_count, "total": len(results), "results": results}
+
+
 def update_plan_servings(plan_id: int, servings: int) -> dict | None:
     with db() as conn:
         conn.execute("UPDATE meal_plan SET servings=? WHERE id=?", (servings, plan_id))

--- a/server.py
+++ b/server.py
@@ -129,6 +129,21 @@ def list_recipes():
     return jsonify(importer.list_recipes(status=status, page=page, per_page=per_page))
 
 
+@app.route("/api/recipes/batch", methods=["POST"])
+def batch_recipes():
+    data = request.get_json() or {}
+    action = data.get("action", "")
+    slugs = data.get("slugs", [])
+    if not action:
+        return jsonify({"error": "action required"}), 400
+    if not isinstance(slugs, list) or not slugs:
+        return jsonify({"error": "slugs must be a non-empty list"}), 400
+    try:
+        return jsonify(importer.batch_recipe_action(action, slugs))
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+
+
 @app.route("/api/recipes/<slug>")
 def get_recipe(slug):
     recipe = importer.get_recipe(slug)
@@ -399,6 +414,17 @@ def add_meal_plan():
         servings=data.get("servings")
     )
     return jsonify(entry), 201
+
+
+@app.route("/api/mealplan/batch", methods=["POST"])
+def add_meal_plan_batch():
+    data = request.get_json() or {}
+    slots = data.get("slots", [])
+    if not isinstance(slots, list) or not slots:
+        return jsonify({"error": "slots must be a non-empty list"}), 400
+    result = meal_planner.add_slots_batch(slots)
+    status = 207 if result["failed"] else 201
+    return jsonify(result), status
 
 
 @app.route("/api/mealplan/<int:plan_id>", methods=["PUT"])

--- a/tests/test_batch_actions.py
+++ b/tests/test_batch_actions.py
@@ -1,0 +1,87 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import core.db as dbmod
+import core.schema as schema
+from core.db import db
+from modules import importer, meal_planner
+
+
+class BatchEndpointHelperTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self.tmp.name)
+        self.old_db_path = dbmod.DB_PATH
+        self.old_recipes_dir = importer.RECIPES_DIR
+        dbmod.DB_PATH = self.base / "chef.db"
+        importer.RECIPES_DIR = self.base / "recipes"
+        schema.init_db()
+        self._save_recipe("alpha", "Alpha", "staged")
+        self._save_recipe("beta", "Beta", "active")
+        self._save_recipe("gamma", "Gamma", "active")
+
+    def tearDown(self):
+        dbmod.DB_PATH = self.old_db_path
+        importer.RECIPES_DIR = self.old_recipes_dir
+        self.tmp.cleanup()
+
+    def _save_recipe(self, slug, name, status):
+        importer.save_recipe_json({
+            "@context": "https://schema.org",
+            "@type": "Recipe",
+            "name": name,
+            "slug": slug,
+            "recipeYield": "2 servings",
+            "recipeIngredient": ["1 cup rice"],
+            "recipeInstructions": [{"@type": "HowToStep", "text": "Cook."}],
+            "status": status,
+        }, status=status)
+
+    def test_batch_recipe_action_returns_per_item_results(self):
+        result = importer.batch_recipe_action("favorite", ["beta", "missing"])
+
+        self.assertEqual(result["total"], 2)
+        self.assertEqual(result["ok"], 1)
+        self.assertEqual(result["failed"], 1)
+        self.assertEqual(result["results"][0], {"slug": "beta", "ok": True, "favorited": True})
+        self.assertEqual(result["results"][1]["slug"], "missing")
+        self.assertFalse(result["results"][1]["ok"])
+
+        with db() as conn:
+            row = conn.execute("SELECT favorited FROM recipes WHERE slug='beta'").fetchone()
+        self.assertEqual(row["favorited"], 1)
+
+    def test_batch_recipe_action_approve_and_trash_updates_statuses(self):
+        approved = importer.batch_recipe_action("approve", ["alpha"])
+        trashed = importer.batch_recipe_action("trash", ["beta"])
+
+        self.assertEqual(approved["ok"], 1)
+        self.assertEqual(trashed["ok"], 1)
+        with db() as conn:
+            statuses = dict(conn.execute("SELECT slug, status FROM recipes").fetchall())
+        self.assertEqual(statuses["alpha"], "active")
+        self.assertEqual(statuses["beta"], "trashed")
+
+        alpha_json = json.loads((importer.RECIPES_DIR / "alpha.json").read_text())
+        beta_json = json.loads((importer.RECIPES_DIR / "beta.json").read_text())
+        self.assertEqual(alpha_json["status"], "active")
+        self.assertEqual(beta_json["status"], "trashed")
+
+    def test_add_slots_batch_returns_success_and_failure_counts(self):
+        result = meal_planner.add_slots_batch([
+            {"date": "2026-05-25", "meal_type": "dinner", "recipe_slug": "beta"},
+            {"date": "2026-05-26", "meal_type": "dinner", "recipe_slug": "missing"},
+        ])
+
+        self.assertEqual(result["total"], 2)
+        self.assertEqual(result["ok"], 1)
+        self.assertEqual(result["failed"], 1)
+        self.assertTrue(result["results"][0]["ok"])
+        self.assertEqual(result["results"][0]["entry"]["recipe_slug"], "beta")
+        self.assertFalse(result["results"][1]["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add recipe batch action support for favorite, unfavorite, trash/discard, approve, restore, and permanent delete with per-item results.
- Add meal-plan batch slot creation for generated week plans and saved templates.
- Update frontend bulk recipe actions and meal-plan apply flows to use one request per bulk operation instead of Promise.all request storms.
- Keep existing single-item endpoints intact.
- Mark Phase 6 done in the lean-refactor roadmap.

## Test Plan
- [x] python3 -m unittest discover -s tests -v
- [x] python3 -m compileall -q core modules server.py
- [x] node --check frontend/recipes.js
- [x] node --check frontend/planner.js
- [x] Flask test-client smoke for /api/recipes/batch and /api/mealplan/batch via uv run
- [x] git diff --check
- [x] docker build -t feedme-phase6-check .
- [x] docker run smoke for /api/settings and /api/recipes/batch

Closes #56