### PR TITLE
refactor: share frontend recipe card rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Versions follow [Semantic Versioning](https://semver.org): `MAJOR.MINOR.PATCH`
 
 ## [Unreleased]
 
+### Changed
+- Recipe, staging, trash, favorites, and planner picker cards now share frontend rendering helpers to keep the vanilla JS UI easier to maintain without changing visible behavior.
+
 ## [v1.8.1] — 2026-05-11
 
 ### Fixed

--- a/docs/roadmap/lean-refactor.md
+++ b/docs/roadmap/lean-refactor.md
@@ -29,7 +29,7 @@ Make Feedme easier for humans and agents to modify while reducing stale docs, AI
 - Phase 4: Done — [#54](https://github.com/sette7blo/feedme/issues/54)
 - Phase 5: Done — [#55](https://github.com/sette7blo/feedme/issues/55)
 - Phase 6: Done — [#56](https://github.com/sette7blo/feedme/issues/56)
-- Phase 7: Planned — [#57](https://github.com/sette7blo/feedme/issues/57)
+- Phase 7: Done — [#57](https://github.com/sette7blo/feedme/issues/57)
 
 ## Phases
 
@@ -101,15 +101,15 @@ Acceptance:
 - [x] Existing single-item endpoints still work.
 
 ### Phase 7 — Lean frontend rendering helpers without adding a build step
-Status: Planned
+Status: Done
 GitHub issue: [#57](https://github.com/sette7blo/feedme/issues/57)
 
 Goal: Reduce duplicated recipe-card markup, inline handlers/styles, and full-grid churn while keeping vanilla JS/no build step.
 
 Acceptance:
-- [ ] Recipe cards render through shared helpers instead of repeated large template blocks.
-- [ ] Visible behavior remains the same.
-- [ ] Frontend files get easier to scan, not fragmented into many tiny scripts.
+- [x] Recipe cards render through shared helpers instead of repeated large template blocks.
+- [x] Visible behavior remains the same.
+- [x] Frontend files get easier to scan, not fragmented into many tiny scripts.
 
 ## Completion rule
 

--- a/frontend/app.css
+++ b/frontend/app.css
@@ -395,6 +395,10 @@ body { font-family: 'Jost', sans-serif; background: var(--cream); color: var(--t
 .card-foot { display: flex; align-items: center; justify-content: space-between; padding-top: 8px; border-top: 1px solid var(--border-soft); font-size: 12px; color: var(--text-dim); }
 .card-meta { display: flex; gap: 8px; }
 .card-last-cooked { font-size: 10px; color: var(--text-muted); padding-top: 4px; }
+.card-last-cooked.never { color: var(--text-muted); opacity: .6; }
+.empty-state { color: var(--text-muted); padding: 24px; font-style: italic; }
+.empty-state a { color: var(--amber); }
+.empty-state-compact { font-size: 13px; padding: 8px 0; }
 .quick-plan-btn { position: absolute; top: 7px; right: 40px; background: rgba(255,255,255,.82); border: none; border-radius: 50%; width: 28px; height: 28px; display: flex; align-items: center; justify-content: center; cursor: pointer; padding: 0; transition: transform .15s, background .15s; z-index: 2; }
 .quick-plan-btn:hover { transform: scale(1.2); background: rgba(255,255,255,.97); }
 .quick-plan-pop { position: absolute; top: 38px; right: 8px; background: var(--white); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); box-shadow: var(--shadow-md); padding: 10px; z-index: 10; min-width: 170px; }

--- a/frontend/core.js
+++ b/frontend/core.js
@@ -45,6 +45,78 @@ function heartBtn(slug, favorited) {
   </button>`;
 }
 
+/* ── Shared render helpers ── */
+function _htmlAttr(s) {
+  return String(s ?? '').replace(/&/g,'&amp;').replace(/"/g,'&quot;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}
+
+function recipeImageUrl(r) {
+  if (!r || !r.image_url) return '';
+  return r.image_url + (r.image_url.startsWith('http') ? '' : '?t=' + (r.updated_at || '').replace(/\D/g, ''));
+}
+
+function recipeImageHtml(r, opts={}) {
+  const src = opts.src || recipeImageUrl(r);
+  const alt = opts.alt ?? r?.name ?? '';
+  const fallback = opts.fallback || (FOOD_SVG[r?.source_type] || FOOD_SVG.manual);
+  const onerror = opts.clearOnError ? `this.parentElement.innerHTML=''` : `this.remove()`;
+  return `${src ? `<img src="${_htmlAttr(src)}" alt="${_htmlAttr(alt)}" loading="lazy" onerror="${onerror}">` : ''}${fallback || ''}`;
+}
+
+function cardMetaHtml(r) {
+  const time = r.total_time || r.cook_time;
+  const timeHtml = time ? `<span><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg> ${time}</span>` : '';
+  const servingsHtml = r.servings ? `<span><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px"><path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg> ${r.servings}</span>` : '';
+  return `${timeHtml}${servingsHtml}`;
+}
+
+function selectionCheckHtml() {
+  return `<div class="sel-check"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></div>`;
+}
+
+function quickPlanButtonHtml(slug) {
+  return `<button class="quick-plan-btn" onclick="event.stopPropagation();toggleQuickPlan(this,'${slug}')" title="Add to meal plan"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--text-mid)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><line x1="12" y1="14" x2="12" y2="18"/><line x1="10" y1="16" x2="14" y2="16"/></svg></button>`;
+}
+
+function renderEmptyState(message, opts={}) {
+  const action = opts.actionHtml || '';
+  if (opts.compact) return `<div class="empty-state empty-state-compact">${message}${action}</div>`;
+  return `<div class="empty-state">${message}${action}</div>`;
+}
+
+function renderRecipeCard(r, opts={}) {
+  const selectable = !!opts.selectionMode;
+  const selected = !!opts.selected;
+  const cardClasses = ['recipe-card', opts.className, selectable ? 'selectable' : '', selected ? 'selected' : '']
+    .filter(Boolean).join(' ');
+  const clickAction = opts.noClick ? '' : (selectable ? `toggleSelectRecipe('${r.slug}')` : (opts.clickAction || `openDrawer('${r.slug}')`));
+  const clickAttr = clickAction ? ` onclick="${clickAction}"` : '';
+  const imageAdornment = selectable ? selectionCheckHtml() : (opts.imageAdornment ?? srcBadge(r.source_type));
+  const favorite = (!selectable && opts.showHeart) ? heartBtn(r.slug, opts.favoriteOverride ?? r.favorited) : '';
+  const quickPlan = (!selectable && opts.showQuickPlan) ? quickPlanButtonHtml(r.slug) : '';
+  const footExtra = opts.footExtra || '';
+  const lastCooked = opts.lastCookedHtml || '';
+  const actions = (!selectable && opts.actionsHtml) ? opts.actionsHtml : '';
+  const style = opts.style ? ` style="${opts.style}"` : '';
+
+  return `
+    <div class="${cardClasses}"${opts.id ? ` id="${opts.id}"` : ''} data-slug="${r.slug}"${clickAttr}${style}>
+      <div class="card-img-wrap">
+        <div class="card-ph">${recipeImageHtml(r)}</div>
+        ${imageAdornment}
+        ${favorite}
+        ${quickPlan}
+      </div>
+      <div class="card-body">
+        <div class="card-cat">${r.category||'—'} · ${r.cuisine||'—'}</div>
+        <div class="card-name">${r.name}</div>
+        ${opts.hideMeta ? '' : `<div class="card-foot"><div class="card-meta">${cardMetaHtml(r)}</div>${footExtra}</div>`}
+        ${lastCooked}
+      </div>
+      ${actions}
+    </div>`;
+}
+
 /* ── Tabs ── */
 let currentTab = 'recipes';
 let _currentSubTabs = {};

--- a/frontend/planner.js
+++ b/frontend/planner.js
@@ -117,15 +117,16 @@ function filterPicker(q) {
 function renderPickerGrid(recipes) {
   if (!recipes.length) {
     document.getElementById('picker-grid').innerHTML =
-      '<div style="color:var(--text-muted);font-size:13px;font-style:italic">No recipes found.</div>';
+      renderEmptyState('No recipes found.', { compact: true });
     return;
   }
   document.getElementById('picker-grid').innerHTML = recipes.map(r => `
     <div class="picker-card" onclick="pickRecipe('${r.slug}')">
       <div class="picker-card-img">
-        ${r.image_url
-          ? `<img src="${r.image_url}" alt="${r.name}" onerror="this.parentElement.innerHTML=''">`
-          : `<svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="var(--border)" stroke-width="1.5" stroke-linecap="round"><circle cx="12" cy="12" r="9"/><path d="M8 12c0-2.2 1.8-4 4-4s4 1.8 4 4"/><path d="M12 16v-4"/></svg>`}
+        ${recipeImageHtml(r, {
+          fallback: `<svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="var(--border)" stroke-width="1.5" stroke-linecap="round"><circle cx="12" cy="12" r="9"/><path d="M8 12c0-2.2 1.8-4 4-4s4 1.8 4 4"/><path d="M12 16v-4"/></svg>`,
+          clearOnError: true,
+        })}
       </div>
       <div class="picker-card-body">
         <div class="picker-card-cat">${r.category||'—'}</div>

--- a/frontend/recipes.js
+++ b/frontend/recipes.js
@@ -143,13 +143,6 @@ function renderRecipes() {
       countEl.style.display = 'none';
     }
   }
-  if (!list.length) {
-    const hasRecipes = recipesData.length > 0;
-    document.getElementById('recipe-grid').innerHTML = hasRecipes
-      ? `<div style="color:var(--text-muted);padding:24px;font-style:italic">No recipes match your filters. <a href="#" onclick="clearFilters();return false" style="color:var(--amber)">Clear filters</a></div>`
-      : `<div style="color:var(--text-muted);padding:24px;font-style:italic">No recipes yet. Generate one with AI or import from RSS.</div>`;
-    return;
-  }
 
   let renderList = [...list];
   if (_cookTonight && _pantryCache) {
@@ -163,38 +156,24 @@ function renderRecipes() {
     renderList.sort((a, b) => (_parseTimeMinutes(a.cook_time || a.total_time) || 999) - (_parseTimeMinutes(b.cook_time || b.total_time) || 999));
   }
 
-  const selCheck = `<div class="sel-check"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></div>`;
+  if (!renderList.length) {
+    const hasRecipes = recipesData.length > 0;
+    document.getElementById('recipe-grid').innerHTML = hasRecipes
+      ? renderEmptyState('No recipes match your filters. ', { actionHtml: '<a href="#" onclick="clearFilters();return false">Clear filters</a>' })
+      : renderEmptyState('No recipes yet. Generate one with AI or import from RSS.');
+    return;
+  }
+
   document.getElementById('recipe-grid').innerHTML = renderList.map(r => {
-    const isSel = _selected.has(r.slug);
-    const clickAction = _selMode
-      ? `toggleSelectRecipe('${r.slug}')`
-      : `openDrawer('${r.slug}')`;
     const covBadge = (_cookTonight && r._cov && r._cov.total > 0)
       ? `<span class="coverage-badge">${r._cov.matched}/${r._cov.total} ingredients</span>`
       : '';
-    return `
-    <div class="recipe-card${_selMode ? ' selectable' : ''}${isSel ? ' selected' : ''}" data-slug="${r.slug}" onclick="${clickAction}">
-      <div class="card-img-wrap">
-        <div class="card-ph">
-          ${r.image_url ? `<img src="${r.image_url}${r.image_url.startsWith('http') ? '' : '?t=' + (r.updated_at||'').replace(/\D/g,'')}" alt="${r.name}" onerror="this.remove()">` : ''}
-          ${FOOD_SVG[r.source_type]||FOOD_SVG.manual}
-        </div>
-        ${_selMode ? selCheck : srcBadge(r.source_type)}
-        ${_selMode ? '' : heartBtn(r.slug, r.favorited)}
-
-      </div>
-      <div class="card-body">
-        <div class="card-cat">${r.category||'—'} · ${r.cuisine||'—'}</div>
-        <div class="card-name">${r.name}</div>
-        <div class="card-foot">
-          <div class="card-meta">
-            ${(r.total_time||r.cook_time) ? `<span><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg> ${r.total_time||r.cook_time}</span>` : ''}
-            ${r.servings  ? `<span><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px"><path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg> ${r.servings}</span>` : ''}
-          </div>
-          ${covBadge}
-        </div>
-      </div>
-    </div>`;
+    return renderRecipeCard(r, {
+      selectionMode: _selMode,
+      selected: _selected.has(r.slug),
+      showHeart: true,
+      footExtra: covBadge,
+    });
   }).join('');
 }
 
@@ -231,40 +210,19 @@ function renderFavorites() {
   if (surpriseBtn) surpriseBtn.style.display = favoritesData.length >= 2 ? '' : 'none';
   if (!list.length) {
     document.getElementById('favorites-grid').innerHTML =
-      `<div style="color:var(--text-muted);padding:24px;font-style:italic">No favorites yet. Press the heart on any recipe to save it here.</div>`;
+      renderEmptyState('No favorites yet. Press the heart on any recipe to save it here.');
     return;
   }
-  const selCheck = `<div class="sel-check"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></div>`;
-  document.getElementById('favorites-grid').innerHTML = list.map(r => {
-    const isSel = _selected.has(r.slug);
-    const clickAction = _selMode
-      ? `toggleSelectRecipe('${r.slug}')`
-      : `openDrawer('${r.slug}')`;
-    return `
-    <div class="recipe-card${_selMode ? ' selectable' : ''}${isSel ? ' selected' : ''}" data-slug="${r.slug}" onclick="${clickAction}">
-      <div class="card-img-wrap">
-        <div class="card-ph">
-          ${r.image_url ? `<img src="${r.image_url}${r.image_url.startsWith('http') ? '' : '?t=' + (r.updated_at||'').replace(/\D/g,'')}" alt="${r.name}" onerror="this.remove()">` : ''}
-          ${FOOD_SVG[r.source_type]||FOOD_SVG.manual}
-        </div>
-        ${_selMode ? selCheck : srcBadge(r.source_type)}
-        ${_selMode ? '' : heartBtn(r.slug, true)}
-        ${_selMode ? '' : `<button class="quick-plan-btn" onclick="event.stopPropagation();toggleQuickPlan(this,'${r.slug}')" title="Add to meal plan"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--text-mid)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><line x1="12" y1="14" x2="12" y2="18"/><line x1="10" y1="16" x2="14" y2="16"/></svg></button>`}
-
-      </div>
-      <div class="card-body">
-        <div class="card-cat">${r.category||'—'} · ${r.cuisine||'—'}</div>
-        <div class="card-name">${r.name}</div>
-        <div class="card-foot">
-          <div class="card-meta">
-            ${(r.total_time||r.cook_time) ? `<span><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg> ${r.total_time||r.cook_time}</span>` : ''}
-            ${r.servings ? `<span><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px"><path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg> ${r.servings}</span>` : ''}
-          </div>
-        </div>
-        ${r.last_cooked ? `<div class="card-last-cooked">Last made ${_daysAgo(r.last_cooked)}</div>` : `<div class="card-last-cooked" style="color:var(--text-muted);opacity:.6">Never cooked</div>`}
-      </div>
-    </div>`;
-  }).join('');
+  document.getElementById('favorites-grid').innerHTML = list.map(r => renderRecipeCard(r, {
+    selectionMode: _selMode,
+    selected: _selected.has(r.slug),
+    showHeart: true,
+    favoriteOverride: true,
+    showQuickPlan: true,
+    lastCookedHtml: r.last_cooked
+      ? `<div class="card-last-cooked">Last made ${_daysAgo(r.last_cooked)}</div>`
+      : `<div class="card-last-cooked never">Never cooked</div>`,
+  })).join('');
 }
 
 function toggleQuickPlan(btn, slug) {
@@ -364,38 +322,20 @@ function updateStageBadge(n) {
 function renderStaged() {
   if (!stagedData.length) {
     document.getElementById('staging-grid').innerHTML =
-      `<div style="color:var(--text-muted);padding:24px;font-style:italic">No recipes pending review.</div>`;
+      renderEmptyState('No recipes pending review.');
     return;
   }
   const trashSvg = `<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/></svg>`;
-  const selCheck = `<div class="sel-check"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></div>`;
-  document.getElementById('staging-grid').innerHTML = stagedData.map(r => {
-    const isSel = _selected.has(r.slug);
-    const clickAction = _selMode
-      ? `toggleSelectRecipe('${r.slug}')`
-      : `openDrawer('${r.slug}')`;
-    return `
-    <div class="recipe-card staged-card${_selMode ? ' selectable' : ''}${isSel ? ' selected' : ''}" data-slug="${r.slug}" onclick="${clickAction}">
-      <div class="card-img-wrap">
-        <div class="card-ph">
-          ${r.image_url ? `<img src="${r.image_url}${r.image_url.startsWith('http') ? '' : '?t=' + (r.updated_at||'').replace(/\D/g,'')}" alt="${r.name}" onerror="this.remove()">` : ''}
-          ${FOOD_SVG[r.source_type]||FOOD_SVG.manual}
-        </div>
-        ${_selMode ? selCheck : srcBadge(r.source_type)}
-
-      </div>
-      <div class="card-body">
-        <div class="card-cat">${r.category||'—'} · ${r.cuisine||'—'}</div>
-        <div class="card-name">${r.name}</div>
-        <div class="card-foot"><div class="card-meta">${(r.total_time||r.cook_time)?`<span><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg> ${r.total_time||r.cook_time}</span>`:''} ${r.servings?`<span><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px"><path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg> ${r.servings}</span>`:''}</div></div>
-      </div>
-      ${_selMode ? '' : `
+  document.getElementById('staging-grid').innerHTML = stagedData.map(r => renderRecipeCard(r, {
+    className: 'staged-card',
+    selectionMode: _selMode,
+    selected: _selected.has(r.slug),
+    actionsHtml: `
       <div class="staged-actions" onclick="event.stopPropagation()">
         <button class="btn btn-xs" style="background:var(--sage);color:white;flex:1" onclick="approveRecipe('${r.slug}')">✓ Keep</button>
         <button class="btn btn-xs" style="background:#c05040;color:white;padding:4px 8px" onclick="trashRecipe('${r.slug}')" title="Discard">${trashSvg}</button>
-      </div>`}
-    </div>`;
-  }).join('');
+      </div>`,
+  })).join('');
 }
 
 async function approveRecipe(slug) {
@@ -947,31 +887,22 @@ async function loadTrashed() {
 function renderTrashed() {
   const btn = document.getElementById('empty-trash-btn');
   if (!trashedData.length) {
-    document.getElementById('trash-grid').innerHTML =
-      `<div style="color:var(--text-muted);padding:24px;font-style:italic">Trash is empty.</div>`;
+    document.getElementById('trash-grid').innerHTML = renderEmptyState('Trash is empty.');
     if (btn) btn.style.display = 'none';
     return;
   }
   if (btn) btn.style.display = '';
-  document.getElementById('trash-grid').innerHTML = trashedData.map(r => `
-    <div class="recipe-card" id="tr-${r.slug}" style="opacity:.72">
-      <div class="card-img-wrap">
-        <div class="card-ph">
-          ${r.image_url ? `<img src="${r.image_url}${r.image_url.startsWith('http') ? '' : '?t=' + (r.updated_at||'').replace(/\D/g,'')}" alt="${r.name}" onerror="this.remove()">` : ''}
-          ${FOOD_SVG[r.source_type]||FOOD_SVG.manual}
-        </div>
-        ${srcBadge(r.source_type)}
-
-      </div>
-      <div class="card-body">
-        <div class="card-cat">${r.category||'—'} · ${r.cuisine||'—'}</div>
-        <div class="card-name">${r.name}</div>
-      </div>
-      <div class="staged-actions">
+  document.getElementById('trash-grid').innerHTML = trashedData.map(r => renderRecipeCard(r, {
+    id: `tr-${r.slug}`,
+    style: 'opacity:.72',
+    hideMeta: true,
+    noClick: true,
+    actionsHtml: `
+      <div class="staged-actions" onclick="event.stopPropagation()">
         <button class="btn btn-xs" style="background:var(--sage);color:white;flex:1" onclick="restoreRecipe('${r.slug}')">↩ Restore</button>
         <button class="btn btn-xs" style="background:#c05040;color:white" onclick="permanentDelete('${r.slug}')">Delete Forever</button>
-      </div>
-    </div>`).join('');
+      </div>`,
+  })).join('');
 }
 
 async function restoreRecipe(slug) {

--- a/tests/test_frontend_render_helpers.py
+++ b/tests/test_frontend_render_helpers.py
@@ -1,0 +1,63 @@
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FRONTEND = ROOT / "frontend"
+
+
+class FrontendRenderHelperTests(unittest.TestCase):
+    def _read(self, filename):
+        return (FRONTEND / filename).read_text()
+
+    def test_core_exposes_shared_recipe_card_helpers(self):
+        core = self._read("core.js")
+
+        for helper in [
+            "recipeImageHtml",
+            "cardMetaHtml",
+            "selectionCheckHtml",
+            "quickPlanButtonHtml",
+            "renderRecipeCard",
+            "renderEmptyState",
+        ]:
+            self.assertRegex(core, rf"function\s+{helper}\s*\(")
+
+        self.assertIn('loading="lazy"', core)
+        self.assertIn('class="empty-state"', core)
+
+    def test_recipe_grids_use_shared_card_renderer_instead_of_repeated_card_templates(self):
+        recipes = self._read("recipes.js")
+
+        for renderer in ["renderRecipes", "renderFavorites", "renderStaged", "renderTrashed"]:
+            body = self._function_body(recipes, renderer)
+            self.assertIn("renderRecipeCard(", body, f"{renderer} should use the shared renderer")
+
+        self.assertLessEqual(recipes.count('class="recipe-card'), 1)
+        self.assertNotIn('class="sel-check"', recipes)
+
+    def test_picker_uses_shared_image_helper_and_lazy_images(self):
+        planner = self._read("planner.js")
+        body = self._function_body(planner, "renderPickerGrid")
+
+        self.assertIn("recipeImageHtml(", body)
+        self.assertNotIn("onerror=", body)
+        self.assertNotIn("<img src=", body)
+
+    def _function_body(self, source, name):
+        match = re.search(rf"function\s+{name}\s*\([^)]*\)\s*{{", source)
+        self.assertIsNotNone(match, f"missing function {name}")
+        start = match.end()
+        depth = 1
+        i = start
+        while i < len(source) and depth:
+            if source[i] == "{":
+                depth += 1
+            elif source[i] == "}":
+                depth -= 1
+            i += 1
+        return source[start:i - 1]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add shared vanilla JS helpers for recipe card images, metadata, selection checks, quick-plan buttons, empty states, and full recipe-card rendering
- Refactor library, favorites, staging, trash, and planner picker rendering to use the shared helpers
- Add frontend structure tests to keep recipe-card rendering consolidated without adding a build step
- Mark Phase 7 complete in the lean-refactor roadmap

## Verification
- [x] python3 -m unittest discover -s tests -v
- [x] python3 -m compileall -q core modules server.py
- [x] node --check frontend/core.js
- [x] node --check frontend/recipes.js
- [x] node --check frontend/planner.js
- [x] git diff --check
- [x] docker build -t feedme-phase7-check .
- [x] Browser smoke: library, favorites, staging, trash, planner, picker modal; no console errors

Closes #57