### PR TITLE
fix: paint startup shell on ios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Versions follow [Semantic Versioning](https://semver.org): `MAJOR.MINOR.PATCH`
 ### Changed
 - Recipe, staging, trash, favorites, and planner picker cards now share frontend rendering helpers to keep the vanilla JS UI easier to maintain without changing visible behavior.
 
+### Fixed
+- iOS startup now paints Feedme's warm background/loading shell immediately instead of showing a plain white screen while CSS, fonts, scripts, or recipe data finish loading.
+
 ## [v1.8.1] — 2026-05-11
 
 ### Fixed

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,9 +8,33 @@
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-title" content="Feedme">
+<style id="startup-paint">
+  html, body { background:#faf7f2; }
+  #boot-paint {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    display: grid;
+    place-items: center;
+    background:#faf7f2;
+    color:#8a6040;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-size: 15px;
+  }
+  #boot-paint .boot-card {
+    padding: 14px 18px;
+    border: 1px solid #e0d4c0;
+    border-radius: 14px;
+    background:#ffffff;
+    box-shadow: 0 6px 28px rgba(44,26,6,.08);
+  }
+  body.app-ready #boot-paint { display:none; }
+</style>
+<link rel="preload" href="/fonts/jost-latin.woff2" as="font" type="font/woff2" crossorigin>
 <link rel="stylesheet" href="/app.css">
 </head>
 <body>
+<div id="boot-paint" aria-live="polite"><div class="boot-card">Loading Feedme…</div></div>
 
 <!-- ═══════════════════════════════════════
      FIXED TOP BANNER
@@ -877,6 +901,7 @@ loadRecipes();
 apiGet('/api/recipes?status=staged&per_page=1').then(d => updateStageBadge(d.total||0)).catch(()=>{});
 const _initSelBtn = document.getElementById('topbar-select-btn');
 if (_initSelBtn) _initSelBtn.style.display = '';
+requestAnimationFrame(() => requestAnimationFrame(() => document.body.classList.add('app-ready')));
 </script>
 
 <!-- Bulk action bar -->

--- a/tests/test_ios_startup_paint.py
+++ b/tests/test_ios_startup_paint.py
@@ -1,0 +1,35 @@
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INDEX = ROOT / "frontend" / "index.html"
+APP_CSS = ROOT / "frontend" / "app.css"
+
+
+class IosStartupPaintTests(unittest.TestCase):
+    def test_index_has_inline_startup_paint_before_blocking_stylesheet(self):
+        html = INDEX.read_text()
+        style_pos = html.index('<style id="startup-paint"')
+        css_pos = html.index('<link rel="stylesheet" href="/app.css">')
+        body_pos = html.index('<body>')
+        boot_pos = html.index('id="boot-paint"')
+
+        self.assertLess(style_pos, css_pos)
+        self.assertGreater(boot_pos, body_pos)
+        self.assertIn('background:#faf7f2', html)
+        self.assertIn('body.app-ready #boot-paint', html)
+
+    def test_startup_script_marks_app_ready_after_first_paint(self):
+        html = INDEX.read_text()
+        self.assertIn("requestAnimationFrame", html)
+        self.assertIn("document.body.classList.add('app-ready')", html)
+
+    def test_no_external_google_font_dependency(self):
+        combined = INDEX.read_text() + APP_CSS.read_text()
+        self.assertNotIn('fonts.googleapis.com', combined)
+        self.assertNotIn('fonts.gstatic.com', combined)
+        self.assertIn('font-display: swap', combined)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add tiny inline startup paint CSS before the blocking stylesheet so iOS shows Feedme's warm background/loading shell immediately instead of a plain white screen
- Hide the startup shell after the first couple animation frames once the app shell has painted
- Preload the primary local font and add regression tests confirming no Google Fonts dependency is used
- Update the changelog

## Verification
- [x] python3 -m unittest tests.test_ios_startup_paint -v
- [x] python3 -m unittest discover -s tests -v
- [x] node --check frontend/core.js
- [x] node --check frontend/recipes.js
- [x] node --check frontend/planner.js
- [x] node --check frontend/generate.js
- [x] node --check frontend/import.js
- [x] node --check frontend/settings.js
- [x] node --check frontend/pantry.js
- [x] git diff --check
- [x] docker build -t feedme-ios-startup-check .
- [x] browser smoke: app loads with no console errors